### PR TITLE
fix: stabilize event refresh state and referral redirects

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/DirectResolutionButton.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/DirectResolutionButton.tsx
@@ -117,6 +117,10 @@ interface ResolutionReportSummary {
     historyIncorrectCount: number
   }>
   currentOutcome: DirectResolutionOutcome | null
+  currentReporterHistory?: {
+    correctCount: number
+    incorrectCount: number
+  }
   eligibility: ResolutionReportEligibility
 }
 
@@ -134,9 +138,17 @@ interface ResolutionReportSummaryCache {
   loadedAt: number
 }
 
+interface PendingResolutionReport {
+  savedAt: number
+  outcome: Exclude<DirectResolutionOutcome, 'unknown'>
+  reporter: ResolutionReporter
+}
+
 const WALLET_TRANSACTION_GAS_BUFFER_NUMERATOR = 3n
 const WALLET_TRANSACTION_GAS_BUFFER_DENOMINATOR = 2n
 const RESOLUTION_REPORT_SUMMARY_FRESHNESS_MS = 15_000
+const PENDING_RESOLUTION_REPORT_TTL_MS = 60 * 60 * 1000
+const PENDING_RESOLUTION_REPORT_STORAGE_PREFIX = 'kuest:pending-resolution-report:'
 
 function createEmptyResolutionReportSummary(): ResolutionReportSummary {
   return {
@@ -149,7 +161,65 @@ function createEmptyResolutionReportSummary(): ResolutionReportSummary {
     outcomeCounts: { yes: 0, no: 0, unknown: 0 },
     reporters: [],
     currentOutcome: null,
+    currentReporterHistory: { correctCount: 0, incorrectCount: 0 },
     eligibility: 'unavailable',
+  }
+}
+
+function getPendingResolutionReportStorageKey(scopeKey: string) {
+  return `${PENDING_RESOLUTION_REPORT_STORAGE_PREFIX}${scopeKey}`
+}
+
+function readPendingResolutionReport(scopeKey: string): PendingResolutionReport | null {
+  try {
+    const raw = window.localStorage.getItem(getPendingResolutionReportStorageKey(scopeKey))
+    if (!raw) {
+      return null
+    }
+    const parsed = JSON.parse(raw) as Partial<PendingResolutionReport>
+    if (
+      !Number.isFinite(parsed.savedAt) ||
+      Date.now() - Number(parsed.savedAt) > PENDING_RESOLUTION_REPORT_TTL_MS ||
+      (parsed.outcome !== 'yes' && parsed.outcome !== 'no') ||
+      !parsed.reporter ||
+      typeof parsed.reporter.seed !== 'string' ||
+      parsed.reporter.outcome !== parsed.outcome
+    ) {
+      window.localStorage.removeItem(getPendingResolutionReportStorageKey(scopeKey))
+      return null
+    }
+    return parsed as PendingResolutionReport
+  } catch {
+    return null
+  }
+}
+
+function writePendingResolutionReport(scopeKey: string, pendingReport: PendingResolutionReport) {
+  try {
+    window.localStorage.setItem(getPendingResolutionReportStorageKey(scopeKey), JSON.stringify(pendingReport))
+  } catch {
+    // Persistence is best-effort; the in-memory optimistic state still applies.
+  }
+}
+
+function clearPendingResolutionReport(scopeKey: string) {
+  try {
+    window.localStorage.removeItem(getPendingResolutionReportStorageKey(scopeKey))
+  } catch {
+    // Ignore unavailable browser storage.
+  }
+}
+
+function mergePendingResolutionReport(
+  summary: ResolutionReportSummary,
+  pendingReport: PendingResolutionReport,
+): ResolutionReportSummary {
+  const { outcome, reporter } = pendingReport
+  return {
+    ...summary,
+    currentOutcome: outcome,
+    outcomeCounts: { ...summary.outcomeCounts, [outcome]: 1 },
+    reporters: [...summary.reporters.filter((currentReporter) => currentReporter.outcome !== outcome), reporter],
   }
 }
 
@@ -985,9 +1055,25 @@ export default function DirectResolutionButton({
           if (!response.ok) {
             throw new Error(`Resolution report summary failed with ${response.status}.`)
           }
-          const summary = (await response.json()) as ResolutionReportSummary
+          let summary = (await response.json()) as ResolutionReportSummary
           if (!isCurrentRequest()) {
             return
+          }
+
+          const pendingReport = readPendingResolutionReport(reportSummaryScopeKey)
+          if (pendingReport) {
+            const pendingWallet = pendingReport.reporter.wallet?.toLowerCase()
+            const pendingReporterIndexed = summary.reporters.some((reporter) => {
+              const reporterWallet = reporter.wallet?.toLowerCase() ?? reporter.seed.toLowerCase()
+              return pendingWallet ? reporterWallet === pendingWallet : reporter.seed === pendingReport.reporter.seed
+            })
+            if (summary.currentOutcome && summary.currentOutcome !== pendingReport.outcome) {
+              clearPendingResolutionReport(reportSummaryScopeKey)
+            } else if (pendingReporterIndexed) {
+              clearPendingResolutionReport(reportSummaryScopeKey)
+            } else {
+              summary = mergePendingResolutionReport(summary, pendingReport)
+            }
           }
 
           reportSummaryRef.current = summary
@@ -1071,6 +1157,24 @@ export default function DirectResolutionButton({
         reportSummaryRequestRef.current = null
       }
     }
+  }, [reportSummaryScopeKey])
+  // oxlint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
+
+  // A confirmed proposal may precede Data API indexing. Restore it across refreshes until
+  // the authoritative summary includes the reporter.
+  // oxlint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
+  useEffect(() => {
+    const pendingReport = readPendingResolutionReport(reportSummaryScopeKey)
+    if (!pendingReport) {
+      return
+    }
+
+    setSelectedOutcome(pendingReport.outcome)
+    setReportSummary((current) => {
+      const nextSummary = mergePendingResolutionReport(current, pendingReport)
+      reportSummaryRef.current = nextSummary
+      return nextSummary
+    })
   }, [reportSummaryScopeKey])
   // oxlint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change
 
@@ -1175,24 +1279,35 @@ export default function DirectResolutionButton({
       setReviewOpen(false)
       setState('submitted')
       setMessage('')
-      setReportSummary((current) => ({
-        ...current,
-        currentOutcome: selectedOutcome,
-        outcomeCounts: { ...current.outcomeCounts, [selectedOutcome]: 1 },
-        reporters: [
-          ...current.reporters.filter((reporter) => reporter.outcome !== selectedOutcome),
-          {
-            seed: user.deposit_wallet_address!,
-            wallet: user.deposit_wallet_address!,
-            username: user.username,
-            image: user.image ?? '',
-            outcome: selectedOutcome,
-            rewardAmount: '0',
-            historyCorrectCount: 0,
-            historyIncorrectCount: 0,
-          },
-        ],
-      }))
+      setReportSummary((current) => {
+        const optimisticReporter = {
+          seed: user.deposit_wallet_address!,
+          wallet: user.deposit_wallet_address!,
+          username: user.username,
+          image: user.image ?? '',
+          outcome: selectedOutcome,
+          rewardAmount: '0',
+          historyCorrectCount: current.currentReporterHistory?.correctCount ?? 0,
+          historyIncorrectCount: current.currentReporterHistory?.incorrectCount ?? 0,
+        }
+        const nextSummary = {
+          ...current,
+          currentOutcome: selectedOutcome,
+          outcomeCounts: { ...current.outcomeCounts, [selectedOutcome]: 1 },
+          reporters: [
+            ...current.reporters.filter((reporter) => reporter.outcome !== selectedOutcome),
+            optimisticReporter,
+          ],
+        }
+        writePendingResolutionReport(reportSummaryScopeKey, {
+          savedAt: Date.now(),
+          outcome: selectedOutcome,
+          reporter: optimisticReporter,
+        })
+        reportSummaryRef.current = nextSummary
+        reportSummaryCacheRef.current = { scopeKey: reportSummaryScopeKey, loadedAt: Date.now() }
+        return nextSummary
+      })
       toast.success(t('Resolution proposal submitted.'))
     } catch (error) {
       console.error('Could not submit resolution report:', error)

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
@@ -13,7 +13,7 @@ import {
   computeChanceChanges,
   resolveEventHistoryEndAt,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
-import { resolveDisplayPrice } from '@/lib/market-chance'
+import { buildChanceByMarket, resolveDisplayPrice } from '@/lib/market-chance'
 
 interface UseEventMarketChanceDataParams {
   event: Event
@@ -41,8 +41,9 @@ export function useEventMarketChanceData({
   const marketLastTradesByMarket = includePriceHistory ? yesPriceHistory.latestRawPrices : fallbackLastTradesByMarket
   const marketQuotesByMarket = useEventMarketQuotes(yesMarketTargets, { enabled })
   const displayChanceByMarket = useMemo(() => {
+    const fallbackChanceByMarket = buildChanceByMarket(event.markets)
     const marketIds = new Set([...Object.keys(marketQuotesByMarket), ...Object.keys(marketLastTradesByMarket)])
-    const entries: Array<[string, number]> = []
+    const entries: Array<[string, number]> = Object.entries(fallbackChanceByMarket)
 
     marketIds.forEach((marketId) => {
       const quote = marketQuotesByMarket[marketId]
@@ -60,7 +61,7 @@ export function useEventMarketChanceData({
     })
 
     return Object.fromEntries(entries)
-  }, [marketLastTradesByMarket, marketQuotesByMarket])
+  }, [event.markets, marketLastTradesByMarket, marketQuotesByMarket])
   const chanceChangeByMarket = useMemo(() => {
     if (!includePriceHistory) {
       return {}

--- a/src/app/[locale]/(platform)/r/[code]/route.ts
+++ b/src/app/[locale]/(platform)/r/[code]/route.ts
@@ -16,13 +16,20 @@ function resolveRedirectTarget(request: Request) {
   return toParam
 }
 
+function createRelativeRedirect(location: string) {
+  return new NextResponse(null, {
+    status: 307,
+    headers: { Location: location },
+  })
+}
+
 export async function GET(request: Request, context: { params: Promise<{ code: string }> }) {
   const { code } = await context.params
   const { data: affiliate } = await AffiliateRepository.getAffiliateByReference(code)
   const redirectTarget = resolveRedirectTarget(request)
 
   if (!affiliate) {
-    return NextResponse.redirect(new URL('/', request.url))
+    return createRelativeRedirect('/')
   }
 
   const cookieValue = JSON.stringify({
@@ -30,7 +37,7 @@ export async function GET(request: Request, context: { params: Promise<{ code: s
     timestamp: Date.now(),
   })
 
-  const response = NextResponse.redirect(new URL(redirectTarget, request.url))
+  const response = createRelativeRedirect(redirectTarget)
   response.cookies.set({
     name: AFFILIATE_COOKIE_NAME,
     value: cookieValue,

--- a/src/app/api/resolution-reports/route.ts
+++ b/src/app/api/resolution-reports/route.ts
@@ -2,7 +2,7 @@ import type { NextRequest } from 'next/server'
 
 import { NextResponse } from 'next/server'
 
-import { fetchResolutionRewardAccountProposals, fetchResolutionRewardMarket } from '@/lib/data-api/resolution-rewards'
+import { fetchResolutionRewardAccount, fetchResolutionRewardMarket } from '@/lib/data-api/resolution-rewards'
 import { ResolutionReportContextRepository } from '@/lib/db/queries/resolution-report-context'
 import { UserRepository } from '@/lib/db/queries/user'
 import { isDirectResolutionConfiguration } from '@/lib/direct-resolution'
@@ -37,27 +37,41 @@ export async function GET(request: NextRequest) {
     }
 
     const depositWallet = currentUser?.deposit_wallet_address?.toLowerCase() ?? null
-    const accountProposals = depositWallet ? await fetchResolutionRewardAccountProposals(depositWallet) : []
+    const rewardAccount = depositWallet ? await fetchResolutionRewardAccount(depositWallet) : null
+    const accountProposals = rewardAccount?.rewardProposals ?? []
     const nowSeconds = Math.floor(Date.now() / 1_000)
     const includeResolvedProposals = rewardMarket.status === 'finalized' || Boolean(rewardMarket.resolvedAt)
-    const proposals = [rewardMarket.noProposal, rewardMarket.yesProposal].filter(
-      (proposal): proposal is NonNullable<typeof proposal> =>
-        Boolean(proposal) &&
-        proposal?.status !== 'expired' &&
-        proposal?.status !== 'released' &&
-        (includeResolvedProposals || proposal?.status !== 'resolved') &&
+    function isVisibleProposal<T extends { status: string; withdrawalAvailableAt: string | null }>(
+      proposal: T | null | undefined,
+    ): proposal is T {
+      return Boolean(
+        proposal &&
+        proposal.status !== 'expired' &&
+        proposal.status !== 'released' &&
+        (includeResolvedProposals || proposal.status !== 'resolved') &&
         !(
-          proposal?.status === 'withdrawal_pending' &&
+          proposal.status === 'withdrawal_pending' &&
           proposal.withdrawalAvailableAt &&
           Number(proposal.withdrawalAvailableAt) <= nowSeconds
         ),
-    )
+      )
+    }
+    const proposals = [rewardMarket.noProposal, rewardMarket.yesProposal].filter(isVisibleProposal)
     // One proposal is allowed per Deposit Wallet for the full market lifetime,
     // including after withdrawal or release.
     const indexedCurrentProposal = accountProposals.find(
       (proposal) => proposal.market.id.toLowerCase() === marketId && proposal.wallet.toLowerCase() === depositWallet,
     )
-    const reporters = proposals.map((proposal) => ({
+    // The account and market indexes can settle in different Data API requests. Keep the
+    // signed-in reporter visible when the account index already knows about the proposal.
+    const visibleProposals = [...proposals]
+    if (
+      isVisibleProposal(indexedCurrentProposal) &&
+      !visibleProposals.some((proposal) => proposal.id === indexedCurrentProposal.id)
+    ) {
+      visibleProposals.push(indexedCurrentProposal)
+    }
+    const reporters = visibleProposals.map((proposal) => ({
       seed: proposal.wallet.toLowerCase(),
       wallet: proposal.wallet,
       username: proposal.profile.username,
@@ -67,7 +81,18 @@ export async function GET(request: NextRequest) {
       historyCorrectCount: parseResolutionHistoryCount(proposal.history.correct) ?? 0,
       historyIncorrectCount: parseResolutionHistoryCount(proposal.history.incorrect) ?? 0,
     }))
-    const activeCurrentOutcome = proposals.find((proposal) => proposal.wallet.toLowerCase() === depositWallet)?.side
+    const activeCurrentOutcome = visibleProposals.find(
+      (proposal) => proposal.wallet.toLowerCase() === depositWallet,
+    )?.side
+    const currentHistorySource = indexedCurrentProposal ?? accountProposals[0] ?? null
+    const currentHistoryCorrect =
+      parseResolutionHistoryCount(rewardAccount?.rewardAccountStats?.correct) ??
+      parseResolutionHistoryCount(currentHistorySource?.history.correct) ??
+      0
+    const currentHistoryIncorrect =
+      parseResolutionHistoryCount(rewardAccount?.rewardAccountStats?.incorrect) ??
+      parseResolutionHistoryCount(currentHistorySource?.history.incorrect) ??
+      0
 
     return NextResponse.json({
       marketId,
@@ -77,11 +102,15 @@ export async function GET(request: NextRequest) {
       withdrawalDelay: rewardMarket.withdrawalDelay,
       rewardEnabled: rewardMarket.status === 'active' && BigInt(rewardMarket.bond) > 0n,
       outcomeCounts: {
-        yes: proposals.some((proposal) => proposal.side === 2) ? 1 : 0,
-        no: proposals.some((proposal) => proposal.side === 1) ? 1 : 0,
+        yes: visibleProposals.some((proposal) => proposal.side === 2) ? 1 : 0,
+        no: visibleProposals.some((proposal) => proposal.side === 1) ? 1 : 0,
         unknown: 0,
       },
       reporters,
+      currentReporterHistory: {
+        correctCount: currentHistoryCorrect,
+        incorrectCount: currentHistoryIncorrect,
+      },
       currentOutcome:
         indexedCurrentProposal?.side === 2
           ? 'yes'

--- a/src/lib/data-api/resolution-rewards.ts
+++ b/src/lib/data-api/resolution-rewards.ts
@@ -154,11 +154,6 @@ export async function fetchResolutionRewardMarket(marketId: string): Promise<Dat
   return payload.rewardMarket ?? null
 }
 
-export async function fetchResolutionRewardAccountProposals(wallet: string): Promise<DataApiRewardProposal[]> {
-  const account = await fetchResolutionRewardAccount(wallet)
-  return account.rewardProposals
-}
-
 export async function fetchResolutionRewardAccount(
   wallet: string,
   options: { signal?: AbortSignal } = {},

--- a/tests/unit/DirectResolutionButton.test.tsx
+++ b/tests/unit/DirectResolutionButton.test.tsx
@@ -115,6 +115,7 @@ const event = {
 
 describe('DirectResolutionButton', () => {
   beforeEach(() => {
+    window.localStorage.clear()
     mocks.fetch.mockReset()
     mocks.readContract.mockReset()
     mocks.readWhitelist.mockReset()
@@ -779,6 +780,7 @@ describe('DirectResolutionButton', () => {
             outcomeCounts: { yes: 0, no: 0, unknown: 0 },
             reporters: [],
             currentOutcome: null,
+            currentReporterHistory: { correctCount: 7, incorrectCount: 2 },
             eligibility: 'eligible',
           }),
         })
@@ -786,7 +788,7 @@ describe('DirectResolutionButton', () => {
       return pendingSummary
     })
 
-    render(<DirectResolutionButton market={market} event={event} />)
+    const { unmount } = render(<DirectResolutionButton market={market} event={event} />)
     expect(await screen.findByText('Bond at risk: $300')).toBeInTheDocument()
     expect(screen.getByText('Reward: $4')).toBeInTheDocument()
     expect(
@@ -807,6 +809,15 @@ describe('DirectResolutionButton', () => {
 
     await waitFor(() => expect(mocks.signAndSubmit).toHaveBeenCalledOnce())
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Review proposal' })).not.toBeInTheDocument())
+    expect(screen.getByLabelText('7 Correct')).toBeInTheDocument()
+    expect(screen.getByLabelText('2 Incorrect')).toBeInTheDocument()
+
+    unmount()
+    render(<DirectResolutionButton market={market} event={event} />)
+
+    expect(await screen.findByRole('button', { name: /Yes/ })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByLabelText('7 Correct')).toBeInTheDocument()
+    expect(screen.getByLabelText('2 Incorrect')).toBeInTheDocument()
   })
 
   it('does not repeat the rules inline and prompts for acceptance before review', async () => {

--- a/tests/unit/affiliateReferralRoute.test.ts
+++ b/tests/unit/affiliateReferralRoute.test.ts
@@ -25,17 +25,39 @@ describe('affiliate referral route', () => {
     })
   })
 
-  it('resolves a username while storing the canonical affiliate code', async () => {
+  it('uses a relative redirect while storing the canonical affiliate code', async () => {
     const { GET } = await import('@/app/[locale]/(platform)/r/[code]/route')
-    const response = await GET(new Request('https://kuest.com/r/alice?to=/event/market'), {
+    const response = await GET(new Request('https://0.0.0.0:3000/r/alice?to=/event/market'), {
       params: Promise.resolve({ code: 'alice' }),
     })
 
     expect(mocks.getAffiliateByReference).toHaveBeenCalledWith('alice')
-    expect(response.headers.get('location')).toBe('https://kuest.com/event/market')
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('/event/market')
     expect(JSON.parse(response.cookies.get('platform_affiliate')?.value ?? '{}')).toEqual({
       affiliateCode: 'a1b2c3d4',
       timestamp: expect.any(Number),
     })
+  })
+
+  it('redirects an unknown reference to the same public origin', async () => {
+    mocks.getAffiliateByReference.mockResolvedValueOnce({ data: null, error: null })
+    const { GET } = await import('@/app/[locale]/(platform)/r/[code]/route')
+    const response = await GET(new Request('https://0.0.0.0:3000/r/missing'), {
+      params: Promise.resolve({ code: 'missing' }),
+    })
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('/')
+    expect(response.cookies.get('platform_affiliate')).toBeUndefined()
+  })
+
+  it('does not allow an external redirect target', async () => {
+    const { GET } = await import('@/app/[locale]/(platform)/r/[code]/route')
+    const response = await GET(new Request('https://0.0.0.0:3000/r/alice?to=https://attacker.test'), {
+      params: Promise.resolve({ code: 'alice' }),
+    })
+
+    expect(response.headers.get('location')).toBe('/')
   })
 })

--- a/tests/unit/resolutionReportRoute.test.ts
+++ b/tests/unit/resolutionReportRoute.test.ts
@@ -6,13 +6,13 @@ const DEPOSIT_WALLET = '0x2222222222222222222222222222222222222222'
 
 const mocks = vi.hoisted(() => ({
   getCurrentUser: vi.fn(),
-  fetchResolutionRewardAccountProposals: vi.fn(),
+  fetchResolutionRewardAccount: vi.fn(),
   fetchResolutionRewardMarket: vi.fn(),
   getMarketConfiguration: vi.fn(),
 }))
 
 vi.mock('@/lib/data-api/resolution-rewards', () => ({
-  fetchResolutionRewardAccountProposals: mocks.fetchResolutionRewardAccountProposals,
+  fetchResolutionRewardAccount: mocks.fetchResolutionRewardAccount,
   fetchResolutionRewardMarket: mocks.fetchResolutionRewardMarket,
 }))
 
@@ -39,7 +39,11 @@ describe('resolution report route', () => {
       oracle: '0x57827d48Da09ba227aFda89C083b4E35972Aa741',
       metadata: JSON.stringify({ resolution_type: 'dro_moov2' }),
     })
-    mocks.fetchResolutionRewardAccountProposals.mockResolvedValue([])
+    mocks.fetchResolutionRewardAccount.mockResolvedValue({
+      rewardAccountStats: null,
+      rewardProposals: [],
+      rewardClaims: [],
+    })
     mocks.fetchResolutionRewardMarket.mockResolvedValue({
       id: MARKET_ID,
       conditionId: 'condition-1',
@@ -136,6 +140,58 @@ describe('resolution report route', () => {
     expect(payload.reporters).toEqual([
       expect.objectContaining({ username: 'winner', outcome: 'yes', rewardAmount: '4000000' }),
     ])
+  })
+
+  it('keeps the current proposal visible while the account and market indexes converge', async () => {
+    const accountProposal = {
+      id: '8',
+      proposalId: '8',
+      market: { id: MARKET_ID },
+      creator: '0x3333333333333333333333333333333333333333',
+      wallet: DEPOSIT_WALLET,
+      side: 1,
+      status: 'active',
+      submittedAt: '2',
+      withdrawalRequestedAt: null,
+      withdrawalAvailableAt: null,
+      correct: null,
+      rewardEligible: true,
+      bondBeneficiary: null,
+      bondAmount: '300000000',
+      rewardAmount: '0',
+      transactionHash: `0x${'2'.repeat(64)}`,
+      profile: { username: 'current-reporter', avatarUrl: 'https://example.test/current.png' },
+      history: { correct: '6', incorrect: '2' },
+    }
+    mocks.fetchResolutionRewardMarket.mockResolvedValueOnce({
+      id: MARKET_ID,
+      conditionId: 'condition-1',
+      bond: '300000000',
+      rewardPool: '4000000',
+      lockDuration: '172800',
+      withdrawalDelay: '86400',
+      status: 'active',
+      noProposal: null,
+      yesProposal: null,
+    })
+    mocks.fetchResolutionRewardAccount.mockResolvedValueOnce({
+      rewardAccountStats: { correct: '7', incorrect: '3' },
+      rewardProposals: [accountProposal],
+      rewardClaims: [],
+    })
+
+    const { GET } = await import('@/app/api/resolution-reports/route')
+    const response = await GET(
+      new NextRequest(`https://example.test/api/resolution-reports?conditionId=condition-1&marketId=${MARKET_ID}`),
+    )
+    const payload = await response.json()
+
+    expect(payload.currentOutcome).toBe('no')
+    expect(payload.outcomeCounts).toEqual({ yes: 0, no: 1, unknown: 0 })
+    expect(payload.reporters).toEqual([
+      expect.objectContaining({ username: 'current-reporter', outcome: 'no', historyCorrectCount: 6 }),
+    ])
+    expect(payload.currentReporterHistory).toEqual({ correctCount: 7, incorrectCount: 3 })
   })
 
   it('rejects a reward market that is not mapped to the requested condition', async () => {

--- a/tests/unit/useEventMarketChanceData.test.tsx
+++ b/tests/unit/useEventMarketChanceData.test.tsx
@@ -1,0 +1,72 @@
+import { renderHook } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useEventMarketChanceData } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData'
+
+const mocks = vi.hoisted(() => ({
+  marketQuotes: {} as Record<string, { bid: number | null; ask: number | null; mid: number | null }>,
+  priceHistory: {
+    normalizedHistory: [],
+    latestSnapshot: {},
+    latestRawPrices: {},
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory', () => ({
+  buildMarketTargets: (markets: Array<{ condition_id: string }>) =>
+    markets.map((market) => ({ conditionId: market.condition_id, tokenId: `${market.condition_id}-token` })),
+  useEventPriceHistory: () => mocks.priceHistory,
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_hooks/useEventLastTrades', () => ({
+  useEventLastTrades: () => ({}),
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices', () => ({
+  useEventMarketQuotes: () => mocks.marketQuotes,
+}))
+
+describe('useEventMarketChanceData', () => {
+  beforeEach(() => {
+    mocks.marketQuotes = {}
+  })
+
+  it('bootstraps the chart chance from the event while CLOB history and snapshots are empty', () => {
+    const event = {
+      id: 'event-1',
+      created_at: '2026-08-11T12:00:00.000Z',
+      markets: [
+        {
+          condition_id: 'condition-1',
+          price: 0.63,
+          outcomes: [{ outcome_index: 0, token_id: 'yes-token' }],
+        },
+      ],
+    } as any
+
+    const { result } = renderHook(() => useEventMarketChanceData({ event, range: 'ALL' }))
+
+    expect(result.current.displayChanceByMarket).toEqual({ 'condition-1': 63 })
+  })
+
+  it('lets a live CLOB quote replace the event bootstrap chance', () => {
+    mocks.marketQuotes = {
+      'condition-1': { bid: 0.67, ask: 0.69, mid: 0.68 },
+    }
+    const event = {
+      id: 'event-1',
+      created_at: '2026-08-11T12:00:00.000Z',
+      markets: [
+        {
+          condition_id: 'condition-1',
+          price: 0.63,
+          outcomes: [{ outcome_index: 0, token_id: 'yes-token' }],
+        },
+      ],
+    } as any
+
+    const { result } = renderHook(() => useEventMarketChanceData({ event, range: 'ALL' }))
+
+    expect(result.current.displayChanceByMarket).toEqual({ 'condition-1': 68 })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes direct resolution state across refreshes and indexing delays, and switches affiliate referral redirects to safe relative 307s. Also boots the event chance chart from event data to avoid empty or flickering states.

- Bug Fixes
  - Direct resolution: persist pending proposals in localStorage (1h TTL) and restore selection/reporters until the Data API indexes; clear when indexed or conflicting. Show `currentReporterHistory` so the user’s correct/incorrect counts stay visible.
  - Resolution reports API: merge account and market indexes to keep the current reporter visible; expose `currentReporterHistory`; filter expired/released/settled withdrawals; replace account proposals fetch with `fetchResolutionRewardAccount`.
  - Event chart: use `buildChanceByMarket` to seed display chance from `event.markets` when quotes/history are empty; update hook deps to include `event.markets`.
  - Referral route: return 307 relative redirects and block external targets; still sets the affiliate cookie.
  - Tests: add coverage for chart bootstrap, direct-resolution persistence and history, referral safety, and API visibility behavior.

<sup>Written for commit e4081fbe82f73adab2ede77135d7b1d9eba7768b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

