### PR TITLE
fix: repair affiliate rewards and user menu

### DIFF
--- a/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
@@ -139,7 +139,13 @@ export default function HeaderDropdownUserMenuGuest() {
         >
           <MenuIcon />
         </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-60" align="end" collisionPadding={16} portalled={false}>
+        <DropdownMenuContent
+          className="w-60"
+          align="end"
+          collisionPadding={16}
+          portalled={false}
+          positionMethod="fixed"
+        >
           <DropdownMenuLinkItem
             render={<Link href="/leaderboard" className="flex w-full items-center gap-1.5" />}
             className="py-2 text-sm font-semibold text-foreground"

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -32,6 +32,7 @@ import { useAppKit } from '@/hooks/useAppKit'
 import { useDepositWalletPolling } from '@/hooks/useDepositWalletPolling'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
+import { resolveReferralSetupStatus, type ReferralSetupStatus } from '@/lib/affiliate-referral'
 import { authClient } from '@/lib/auth-client'
 import { clearCommunityAuth, ensureCommunityToken, parseCommunityError } from '@/lib/community-auth'
 import {
@@ -47,6 +48,7 @@ import {
   CTF_EXCHANGE_ADDRESS,
   NEG_RISK_CTF_EXCHANGE_ADDRESS,
   UMA_NEG_RISK_ADAPTER_ADDRESS,
+  ZERO_ADDRESS,
 } from '@/lib/contracts'
 import { fetchReferralLocked } from '@/lib/exchange'
 import { SUMSUB_ENFORCEMENTS } from '@/lib/sumsub/types'
@@ -234,7 +236,11 @@ function mergeUserSettings(previous: User, settingsPatch?: Record<string, any>) 
   }
 }
 
-function useOnboardingStatus(user: User | null, requiresTradingAuthRefresh: boolean) {
+function useOnboardingStatus(
+  user: User | null,
+  requiresTradingAuthRefresh: boolean,
+  referralSetupStatus: ReferralSetupStatus,
+) {
   return useMemo(() => {
     const onboardingSettings = user?.settings?.onboarding ?? {}
     const tradingAuthSettings = user?.settings?.tradingAuth ?? null
@@ -257,7 +263,10 @@ function useOnboardingStatus(user: User | null, requiresTradingAuthRefresh: bool
     )
     const hasTokenApprovals = Boolean(tradingAuthSettings?.approvals?.enabled)
     const hasAutoRedeemApproval = Boolean(tradingAuthSettings?.autoRedeem?.enabled)
-    const tradingReady = hasDeployedDepositWallet && hasTradingAuth && hasTokenApprovals
+    const isReferralSetupPending = referralSetupStatus === 'checking'
+    const needsReferralSetup = referralSetupStatus === 'required'
+    const hasReferralSetup = !isReferralSetupPending && !needsReferralSetup
+    const tradingReady = hasDeployedDepositWallet && hasTradingAuth && hasTokenApprovals && hasReferralSetup
 
     return {
       needsUsername,
@@ -267,10 +276,12 @@ function useOnboardingStatus(user: User | null, requiresTradingAuthRefresh: bool
       isDepositWalletDeploying,
       hasTradingAuth,
       hasTokenApprovals,
+      isReferralSetupPending,
+      needsReferralSetup,
       hasAutoRedeemApproval,
       tradingReady,
     }
-  }, [requiresTradingAuthRefresh, user])
+  }, [referralSetupStatus, requiresTradingAuthRefresh, user])
 }
 
 function resolveNextOnboardingModal({
@@ -279,6 +290,8 @@ function resolveNextOnboardingModal({
   hasDeployedDepositWallet,
   hasTradingAuth,
   hasTokenApprovals,
+  isReferralSetupPending,
+  needsReferralSetup,
   allowTradingAuthPrompt,
   needsSumsub,
 }: {
@@ -287,6 +300,8 @@ function resolveNextOnboardingModal({
   hasDeployedDepositWallet: boolean
   hasTradingAuth: boolean
   hasTokenApprovals: boolean
+  isReferralSetupPending: boolean
+  needsReferralSetup: boolean
   allowTradingAuthPrompt: boolean
   needsSumsub: boolean
 }): Exclude<OnboardingModal, null> | null {
@@ -305,7 +320,10 @@ function resolveNextOnboardingModal({
   if (allowTradingAuthPrompt && !hasTradingAuth) {
     return 'enable-status'
   }
-  if (allowTradingAuthPrompt && !hasTokenApprovals) {
+  if (isReferralSetupPending) {
+    return null
+  }
+  if (allowTradingAuthPrompt && (!hasTokenApprovals || needsReferralSetup)) {
     return 'approve'
   }
   return null
@@ -447,6 +465,7 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
   const [approvalsStep, setApprovalsStep] = useState<ApprovalsStep>('idle')
   const [autoRedeemStep, setAutoRedeemStep] = useState<ApprovalsStep>('idle')
   const [requiresTradingAuthRefresh, setRequiresTradingAuthRefresh] = useState(false)
+  const [referralSetupStatus, setReferralSetupStatus] = useState<ReferralSetupStatus>('not-required')
   const [shouldContinueTradingAuthPrompt, setShouldContinueTradingAuthPrompt] = useState(false)
   const [sumsubStatus, setSumsubStatus] = useState<SumsubVerificationStatus>({
     enabled: false,
@@ -512,7 +531,59 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
     [openAppKit, signatureRejectedMessage, walletConnectorReconnectMessage],
   )
 
-  const status = useOnboardingStatus(user, requiresTradingAuthRefresh)
+  useEffect(
+    function verifyAffiliateReferralSetup() {
+      const hasReferredUser = Boolean(user?.referred_by_user_id)
+      if (!hasReferredUser) {
+        setReferralSetupStatus('not-required')
+        return
+      }
+
+      if (affiliateMetadata.isLoading) {
+        setReferralSetupStatus('checking')
+        return
+      }
+
+      const depositWalletAddress = user?.deposit_wallet_address
+      const hasAffiliateMetadata =
+        affiliateMetadata.referrerAddress !== ZERO_ADDRESS && affiliateMetadata.affiliateAddress !== ZERO_ADDRESS
+      if (!depositWalletAddress || user?.deposit_wallet_status !== 'deployed' || !hasAffiliateMetadata) {
+        setReferralSetupStatus('required')
+        return
+      }
+
+      let cancelled = false
+      setReferralSetupStatus('checking')
+      const exchanges = [CTF_EXCHANGE_ADDRESS, NEG_RISK_CTF_EXCHANGE_ADDRESS] as const
+      void Promise.all(
+        exchanges.map((exchange) => fetchReferralLocked(exchange, depositWalletAddress as `0x${string}`, viemRpcUrls)),
+      ).then((results) => {
+        if (cancelled) {
+          return
+        }
+        const resolvedStatus = resolveReferralSetupStatus(results)
+        if (results.includes(null)) {
+          console.warn('Failed to verify affiliate referral status; referral setup remains required.')
+        }
+        setReferralSetupStatus(resolvedStatus)
+      })
+
+      return () => {
+        cancelled = true
+      }
+    },
+    [
+      affiliateMetadata.affiliateAddress,
+      affiliateMetadata.isLoading,
+      affiliateMetadata.referrerAddress,
+      user?.deposit_wallet_address,
+      user?.deposit_wallet_status,
+      user?.referred_by_user_id,
+      viemRpcUrls,
+    ],
+  )
+
+  const status = useOnboardingStatus(user, requiresTradingAuthRefresh, referralSetupStatus)
   const sumsubApproved = sumsubStatus.status === 'approved'
   const sumsubRequired = sumsubStatus.effective && sumsubStatus.enforcement === 'required'
   const needsSumsub = sumsubStatus.effective && !sumsubApproved
@@ -1275,7 +1346,7 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
         exchanges.map((exchange) => fetchReferralLocked(exchange, depositWallet, viemRpcUrls)),
       )
       if (results.includes(null)) {
-        console.warn('Failed to read referral status; skipping locked/unknown exchanges.')
+        throw new Error(DEFAULT_ERROR_MESSAGE)
       }
       return exchanges.filter((_, index) => results[index] === false)
     },
@@ -1394,6 +1465,14 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
     setTokenApprovalError(null)
 
     try {
+      if (
+        user.referred_by_user_id &&
+        (affiliateMetadata.isLoading ||
+          affiliateMetadata.referrerAddress === ZERO_ADDRESS ||
+          affiliateMetadata.affiliateAddress === ZERO_ADDRESS)
+      ) {
+        throw new Error(DEFAULT_ERROR_MESSAGE)
+      }
       const referralExchanges = await resolveReferralExchanges(user.deposit_wallet_address as `0x${string}`)
       const missingApprovalCalls = await resolveMissingApprovalCalls(user.deposit_wallet_address as `0x${string}`)
       const calls = [
@@ -1456,6 +1535,10 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
           }
         })
         void refreshSessionUserState()
+      }
+
+      if (user.referred_by_user_id && affiliateMetadata.affiliateAddress !== ZERO_ADDRESS) {
+        setReferralSetupStatus('configured')
       }
 
       if (
@@ -1780,7 +1863,7 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
         onEnableTradingAuth={handleEnableTradingAuth}
         hasDeployedDepositWallet={status.hasDeployedDepositWallet}
         hasTradingAuth={status.hasTradingAuth}
-        hasTokenApprovals={status.hasTokenApprovals}
+        hasTokenApprovals={status.hasTokenApprovals && !status.needsReferralSetup}
         approvalsStep={approvalsStep}
         tokenApprovalError={tokenApprovalError}
         onApproveTokens={handleApproveTokens}

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -32,7 +32,12 @@ import { useAppKit } from '@/hooks/useAppKit'
 import { useDepositWalletPolling } from '@/hooks/useDepositWalletPolling'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
-import { resolveReferralSetupStatus, type ReferralSetupStatus } from '@/lib/affiliate-referral'
+import {
+  resolveReferralExchangeReads,
+  resolveReferralSetupStatus,
+  type ReferralExchangeReadResult,
+  type ReferralSetupStatus,
+} from '@/lib/affiliate-referral'
 import { authClient } from '@/lib/auth-client'
 import { clearCommunityAuth, ensureCommunityToken, parseCommunityError } from '@/lib/community-auth'
 import {
@@ -1340,15 +1345,16 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
   ])
 
   const resolveReferralExchanges = useCallback(
-    async (depositWallet: `0x${string}`) => {
+    async (depositWallet: `0x${string}`): Promise<ReferralExchangeReadResult<`0x${string}`>> => {
       const exchanges = [CTF_EXCHANGE_ADDRESS as `0x${string}`, NEG_RISK_CTF_EXCHANGE_ADDRESS as `0x${string}`]
       const results = await Promise.all(
         exchanges.map((exchange) => fetchReferralLocked(exchange, depositWallet, viemRpcUrls)),
       )
-      if (results.includes(null)) {
-        throw new Error(DEFAULT_ERROR_MESSAGE)
+      const resolution = resolveReferralExchangeReads(exchanges, results)
+      if (!resolution.fullyChecked) {
+        console.warn('Failed to read referral status; skipping unknown exchanges until the next approval attempt.')
       }
-      return exchanges.filter((_, index) => results[index] === false)
+      return resolution
     },
     [viemRpcUrls],
   )
@@ -1465,15 +1471,16 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
     setTokenApprovalError(null)
 
     try {
-      if (
-        user.referred_by_user_id &&
-        (affiliateMetadata.isLoading ||
-          affiliateMetadata.referrerAddress === ZERO_ADDRESS ||
-          affiliateMetadata.affiliateAddress === ZERO_ADDRESS)
-      ) {
-        throw new Error(DEFAULT_ERROR_MESSAGE)
-      }
-      const referralExchanges = await resolveReferralExchanges(user.deposit_wallet_address as `0x${string}`)
+      const needsReferralSetup = Boolean(user.referred_by_user_id)
+      const hasAffiliateMetadata =
+        !affiliateMetadata.isLoading &&
+        affiliateMetadata.referrerAddress !== ZERO_ADDRESS &&
+        affiliateMetadata.affiliateAddress !== ZERO_ADDRESS
+      const referralResolution =
+        needsReferralSetup && hasAffiliateMetadata
+          ? await resolveReferralExchanges(user.deposit_wallet_address as `0x${string}`)
+          : { exchangesToConfigure: [], fullyChecked: !needsReferralSetup }
+      const referralSetupComplete = !needsReferralSetup || (hasAffiliateMetadata && referralResolution.fullyChecked)
       const missingApprovalCalls = await resolveMissingApprovalCalls(user.deposit_wallet_address as `0x${string}`)
       const calls = [
         ...missingApprovalCalls,
@@ -1481,7 +1488,7 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
           referrer: affiliateMetadata.referrerAddress,
           affiliate: affiliateMetadata.affiliateAddress,
           affiliateSharePercent: affiliateMetadata.affiliateSharePercent,
-          exchanges: referralExchanges,
+          exchanges: referralResolution.exchangesToConfigure,
         }),
       ]
       const result =
@@ -1537,11 +1544,12 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
         void refreshSessionUserState()
       }
 
-      if (user.referred_by_user_id && affiliateMetadata.affiliateAddress !== ZERO_ADDRESS) {
-        setReferralSetupStatus('configured')
+      if (needsReferralSetup) {
+        setReferralSetupStatus(referralSetupComplete ? 'configured' : 'required')
       }
 
       if (
+        referralSetupComplete &&
         status.hasDeployedDepositWallet &&
         status.hasTradingAuth &&
         sumsubLoaded &&

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -2,6 +2,7 @@
 
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
+import { useTheme } from 'next-themes'
 import { useEffect, useMemo, useState } from 'react'
 
 import type { EmbedCodeLine } from '@/lib/embed-code'
@@ -226,6 +227,7 @@ function useEmbedCodeBuilders({
       lines.push(attributeLine('\t\t', 'affiliate', affiliateCode))
     }
 
+    lines.push(attributeLine('\t\t', 'transparent', ''))
     lines.push(attributeLine('\t\t', 'theme', theme))
     lines.push(tagSelfCloseLine('\t'))
     lines.push(tagCloseLine('', 'div'))
@@ -236,7 +238,11 @@ function useEmbedCodeBuilders({
   return { features, iframeSrc, previewSrc, iframeCode, webComponentCode, iframeLines, webComponentLines }
 }
 
-function createInitialEditorState(markets: Market[], initialMarketId?: string | null): EditorState {
+function createInitialEditorState(
+  markets: Market[],
+  initialMarketId: string | null | undefined,
+  initialTheme: EmbedTheme,
+): EditorState {
   return {
     copied: false,
     embedType: 'iframe',
@@ -244,7 +250,7 @@ function createInitialEditorState(markets: Market[], initialMarketId?: string | 
     showChart: false,
     showTimeRange: false,
     showVolume: false,
-    theme: 'light',
+    theme: initialTheme,
   }
 }
 
@@ -254,9 +260,12 @@ function EventChartEmbedDialogEditor({
 }: Pick<EventChartEmbedDialogProps, 'markets' | 'initialMarketId'>) {
   const t = useExtracted()
   const site = useSiteIdentity()
+  const { resolvedTheme } = useTheme()
   const { siteUrl } = usePublicRuntimeConfig()
   const user = useUser()
-  const [editorState, setEditorState] = useState(() => createInitialEditorState(markets, initialMarketId))
+  const [editorState, setEditorState] = useState(() =>
+    createInitialEditorState(markets, initialMarketId, resolvedTheme === 'dark' ? 'dark' : 'light'),
+  )
   const affiliateCode = user?.username?.trim() || user?.affiliate_code?.trim() || ''
   const { affiliateSharePercent, builderTakerSharePercent } = useAffiliateSettings(affiliateCode)
   const { copied, embedType, selectedMarketId, showChart, showTimeRange, showVolume, theme } = editorState
@@ -478,7 +487,7 @@ function EventChartEmbedDialogEditor({
       <div className="order-1 flex h-full min-w-0 flex-col gap-3 lg:order-2">
         <Label className="text-xs font-semibold tracking-wide text-muted-foreground">{t('PREVIEW')}</Label>
         <div
-          className="flex min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md bg-[#f7f7f9] p-2"
+          className="flex min-w-0 flex-1 items-center justify-center overflow-hidden rounded-md bg-transparent p-0"
           style={{ minHeight: `${iframeHeight}px` }}
         >
           <iframe

--- a/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
@@ -3,6 +3,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useExtracted, useLocale } from 'next-intl'
+import { useTheme } from 'next-themes'
 import { useMemo, useState } from 'react'
 
 import type { EmbedCodeLine } from '@/lib/embed-code'
@@ -76,6 +77,7 @@ function buildAffiliateIframeSrc(
   const params = new URLSearchParams({
     category: categorySlug,
     theme,
+    transparent: 'true',
     rotate: 'true',
     locale,
   })
@@ -104,6 +106,7 @@ function buildAffiliatePreviewSrc(
   const params = new URLSearchParams({
     category: categorySlug,
     theme,
+    transparent: 'true',
     rotate: 'true',
     locale,
   })
@@ -153,12 +156,17 @@ const IFRAME_HEIGHT_WITH_CHART = 400
 const IFRAME_HEIGHT_WITH_FILTERS = 440
 const IFRAME_HEIGHT_NO_CHART = 180
 
-function useEmbedOptions() {
-  const [theme, setTheme] = useState<EmbedTheme>('light')
+function useEmbedOptions(initialTheme: EmbedTheme) {
+  const [selectedTheme, setSelectedTheme] = useState<EmbedTheme | null>(null)
   const [embedType, setEmbedType] = useState<EmbedType>('iframe')
   const [showVolume, setShowVolume] = useState(false)
   const [showChart, setShowChart] = useState(false)
   const [showTimeRange, setShowTimeRange] = useState(false)
+  const theme = selectedTheme ?? initialTheme
+
+  function setTheme(nextTheme: EmbedTheme) {
+    setSelectedTheme(nextTheme)
+  }
 
   function handleShowChartChange(nextValue: boolean) {
     setShowChart(nextValue)
@@ -357,6 +365,7 @@ function useEmbedCode({
       lines.push(attributeLine('\t\t', 'affiliate', affiliateCode))
     }
 
+    lines.push(attributeLine('\t\t', 'transparent', ''))
     lines.push(attributeLine('\t\t', 'theme', theme))
     lines.push(tagSelfCloseLine('\t'))
     lines.push(tagCloseLine('', 'div'))
@@ -378,6 +387,7 @@ export default function AffiliateWidgetDialog({ open, onOpenChange, categories }
   const t = useExtracted()
   const isMobile = useIsMobile()
   const locale = useLocale()
+  const { resolvedTheme } = useTheme()
   const site = useSiteIdentity()
   const { siteUrl } = usePublicRuntimeConfig()
   const user = useUser()
@@ -393,17 +403,17 @@ export default function AffiliateWidgetDialog({ open, onOpenChange, categories }
     showTimeRange,
     setShowTimeRange,
     handleShowChartChange,
-  } = useEmbedOptions()
+  } = useEmbedOptions(resolvedTheme === 'dark' ? 'dark' : 'light')
   const { copied, setCopied } = useCopyFlashState()
   const { selectedCategory, setSelectedCategoryState } = useEmbedCategorySelection(categories)
   const siteSlug = useSiteSlug(site.name)
   const embedBaseUrl = useMemo(() => normalizeEmbedBaseUrl(siteUrl), [siteUrl])
   const { affiliateSharePercent, builderTakerSharePercent } = useAffiliateFeeSettings(affiliateCode)
-  const {
-    data: currentMarkets = [],
-    isFetching: isFetchingCategory,
-    isError: categoryLoadFailed,
-  } = useCategoryMarkets({ enabled: open, locale, selectedCategory })
+  const { data: currentMarkets = [], isError: categoryLoadFailed } = useCategoryMarkets({
+    enabled: open,
+    locale,
+    selectedCategory,
+  })
   const selectedMarket = currentMarkets[0]
   const embedElementName = `${siteSlug}-market-embed`
   const embedIframeTitle = `${siteSlug}-market-iframe`
@@ -456,8 +466,6 @@ export default function AffiliateWidgetDialog({ open, onOpenChange, categories }
       console.error(error)
     }
   }
-
-  const isLoadingCategory = isFetchingCategory
 
   const embedBody = (
     <div className="grid items-stretch gap-6 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
@@ -572,12 +580,10 @@ export default function AffiliateWidgetDialog({ open, onOpenChange, categories }
       <div className="flex h-full flex-col gap-3">
         <Label className="text-xs font-semibold tracking-wide text-muted-foreground">{t('PREVIEW')}</Label>
         <div
-          className="relative flex flex-1 items-center justify-center overflow-hidden rounded-md bg-[#f7f7f9] p-2"
+          className="relative flex flex-1 items-center justify-center overflow-hidden rounded-md bg-transparent p-0"
           style={{ minHeight: `${iframeHeight}px` }}
         >
-          {isLoadingCategory ? (
-            <p className="text-sm text-muted-foreground">{t('Searching events...')}</p>
-          ) : previewSrc ? (
+          {previewSrc ? (
             <iframe
               title={t('Embed preview')}
               src={previewSrc}

--- a/src/app/[locale]/(platform)/settings/rewards/page.tsx
+++ b/src/app/[locale]/(platform)/settings/rewards/page.tsx
@@ -12,9 +12,9 @@ import { getAffiliateFeeSettings } from '@/lib/affiliate-fee-settings'
 import {
   baseUnitsToNumber,
   combineDailyFeeSeries,
+  fetchFeeHistoryTotal,
   fetchFeeHistoryTimeSeries,
   fetchFeeReceiverTotals,
-  sumFeeTotals,
   sumFeeVolumes,
 } from '@/lib/data-api/fees'
 import { fetchResolutionRewardAccount, fetchResolutionRewardMarket } from '@/lib/data-api/resolution-rewards'
@@ -103,6 +103,7 @@ export default async function RewardsSettingsPage({ params }: RewardsSettingsPag
     ? fetchFeeReceiverTotals({
         endpoint: 'referrers',
         address: receiverAddress,
+        feeType: 'AFFILIATE',
       }).catch((error) => {
         console.warn('Failed to load affiliate fee totals', error)
         return null
@@ -111,6 +112,12 @@ export default async function RewardsSettingsPage({ params }: RewardsSettingsPag
   const affiliateSeriesPromise = receiverAddress
     ? fetchFeeHistoryTimeSeries(receiverAddress, 'AFFILIATE').catch((error) => {
         console.warn('Failed to load affiliate fee history', error)
+        return null
+      })
+    : Promise.resolve(null)
+  const affiliateTotalPromise = receiverAddress
+    ? fetchFeeHistoryTotal(receiverAddress, 'AFFILIATE').catch((error) => {
+        console.warn('Failed to load affiliate fee total', error)
         return null
       })
     : Promise.resolve(null)
@@ -128,6 +135,7 @@ export default async function RewardsSettingsPage({ params }: RewardsSettingsPag
     { data: mainTags },
     feeTotals,
     affiliateFeeSeries,
+    affiliateFeeTotal,
     resolutionAccount,
   ] = await Promise.all([
     SettingsRepository.getSettings(),
@@ -136,6 +144,7 @@ export default async function RewardsSettingsPage({ params }: RewardsSettingsPag
     TagRepository.getMainTags(resolvedLocale),
     feeTotalsPromise,
     affiliateSeriesPromise,
+    affiliateTotalPromise,
     resolutionAccountPromise,
   ])
   const affiliateFeeSettings = getAffiliateFeeSettings(allSettings)
@@ -159,11 +168,16 @@ export default async function RewardsSettingsPage({ params }: RewardsSettingsPag
   let totalAffiliateFees = 0
   let referredVolume = 0
 
+  if (affiliateFeeTotal) {
+    try {
+      totalAffiliateFees = baseUnitsToNumber(BigInt(affiliateFeeTotal.totalAmount), 6)
+    } catch (error) {
+      console.warn('Ignoring malformed affiliate fee total.', { amount: affiliateFeeTotal.totalAmount, error })
+    }
+  }
+
   if (feeTotals) {
-    const usdcTotal = sumFeeTotals(feeTotals)
-    const volumeTotal = sumFeeVolumes(feeTotals)
-    totalAffiliateFees = baseUnitsToNumber(usdcTotal, 6)
-    referredVolume = baseUnitsToNumber(volumeTotal, 6)
+    referredVolume = sumFeeVolumes(feeTotals.filter((total) => total.feeType === 'AFFILIATE'))
   }
 
   const commissionPercent = affiliateFeeSettings.affiliateShareBps / 100

--- a/src/app/[locale]/admin/affiliate/page.tsx
+++ b/src/app/[locale]/admin/affiliate/page.tsx
@@ -10,7 +10,7 @@ import {
   getAffiliateFeeSettings,
   getAffiliateFeeSettingsUpdatedAt,
 } from '@/lib/affiliate-fee-settings'
-import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals, sumFeeVolumes } from '@/lib/data-api/fees'
+import { fetchFeeReceiverTotals, sumFeeTotals, sumFeeVolumes } from '@/lib/data-api/fees'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { getPublicAssetUrl } from '@/lib/storage'
@@ -138,7 +138,9 @@ async function AdminAffiliateContent() {
     )
 
     const feeTotals = await Promise.allSettled(
-      uniqueReceivers.map((address) => fetchFeeReceiverTotals({ endpoint: 'referrers', address })),
+      uniqueReceivers.map((address) =>
+        fetchFeeReceiverTotals({ endpoint: 'referrers', address, feeType: 'AFFILIATE' }),
+      ),
     )
 
     feeTotals.forEach((result, idx) => {
@@ -146,11 +148,12 @@ async function AdminAffiliateContent() {
         console.warn('Failed to load affiliate fee totals', result.reason)
         return
       }
-      const usdcTotal = sumFeeTotals(result.value)
-      const volumeTotal = sumFeeVolumes(result.value)
+      const affiliateTotals = result.value.filter((total) => total.feeType === 'AFFILIATE')
+      const usdcTotal = sumFeeTotals(affiliateTotals)
+      const volumeTotal = sumFeeVolumes(affiliateTotals)
       feeTotalsByAddress.set(uniqueReceivers[idx].toLowerCase(), {
-        fees: baseUnitsToNumber(usdcTotal, 6),
-        volume: baseUnitsToNumber(volumeTotal, 6),
+        fees: usdcTotal,
+        volume: volumeTotal,
       })
     })
   }

--- a/src/app/market.html/route.ts
+++ b/src/app/market.html/route.ts
@@ -13,6 +13,33 @@ function escapeAttr(value: string) {
   return value.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
 }
 
+function buildEmbedThemeStyle(palette: Record<string, string | undefined>, radius: string | null) {
+  function pick(...tokens: string[]) {
+    return tokens.map((token) => palette[token]).find(Boolean)
+  }
+
+  const variables = new Map<string, string | undefined>([
+    ['--kuest-card-background', pick('card', 'background')],
+    ['--kuest-card-border-color', pick('border')],
+    ['--kuest-color-black', pick('card-foreground', 'foreground')],
+    ['--kuest-color-gray-2', pick('secondary-foreground', 'muted-foreground')],
+    ['--kuest-color-gray-3', pick('muted-foreground')],
+    ['--kuest-color-gray-5', pick('muted', 'accent')],
+    ['--kuest-color-gray-6', pick('secondary', 'border')],
+    ['--kuest-color-red', pick('no', 'destructive')],
+    ['--kuest-color-green', pick('yes')],
+    ['--kuest-chart-text-color', pick('muted-foreground')],
+    ['--kuest-chart-grid-color', pick('border')],
+    ['--kuest-chart-crosshair-color', pick('ring')],
+    ['--kuest-chart-line-color', pick('chart-1', 'primary')],
+    ['--kuest-radii-md', radius ?? undefined],
+  ])
+
+  return Array.from(variables.entries())
+    .flatMap(([name, value]) => (value ? [`${name}: ${value}`] : []))
+    .join('; ')
+}
+
 async function resolveInitialCategoryMarketSlug(
   categorySlug: string,
   mainCategorySlug: string,
@@ -56,6 +83,7 @@ export async function GET(request: NextRequest) {
   const shouldRotateCategory = Boolean(categorySlug) && rotateCategory
   const affiliateCode = searchParams.get('r')?.trim() ?? ''
   const theme = searchParams.get('theme') === 'dark' ? 'dark' : 'light'
+  const transparent = searchParams.get('transparent') === 'true'
   const features = new Set(
     (searchParams.get('features') ?? '')
       .split(',')
@@ -78,8 +106,16 @@ export async function GET(request: NextRequest) {
     ? await resolveInitialCategoryMarketSlug(categorySlug, mainCategorySlug, resolvedLocale)
     : ''
   const resolvedMarketSlug = marketSlug || initialCategoryMarketSlug
+  const themePalette = theme === 'dark' ? runtimeTheme.theme.dark : runtimeTheme.theme.light
+  const embedThemeStyle = buildEmbedThemeStyle(themePalette, runtimeTheme.theme.radius)
 
   const attrs: string[] = [`theme="${theme}"`]
+  if (transparent) {
+    attrs.push('transparent')
+  }
+  if (embedThemeStyle) {
+    attrs.push(`style="${escapeAttr(embedThemeStyle)}"`)
+  }
   if (resolvedMarketSlug) {
     attrs.push(`market="${escapeAttr(resolvedMarketSlug)}"`)
   } else if (eventSlug) {
@@ -167,6 +203,8 @@ export async function GET(request: NextRequest) {
         }
 
         const initialTheme = widget.getAttribute('theme') ?? 'light';
+        const initialTransparent = widget.hasAttribute('transparent');
+        const initialStyle = widget.getAttribute('style') ?? '';
         const initialEvent = widget.getAttribute('event') ?? '';
         const initialVolume = widget.getAttribute('volume') ?? '';
         const initialChart = widget.getAttribute('chart') ?? '';
@@ -179,6 +217,12 @@ export async function GET(request: NextRequest) {
         function mountWidget(marketSlug) {
           const nextWidget = document.createElement(${JSON.stringify(elementName)});
           nextWidget.setAttribute('theme', initialTheme);
+          if (initialTransparent) {
+            nextWidget.setAttribute('transparent', '');
+          }
+          if (initialStyle) {
+            nextWidget.setAttribute('style', initialStyle);
+          }
           if (marketSlug) {
             nextWidget.setAttribute('market', marketSlug);
           }
@@ -225,7 +269,10 @@ export async function GET(request: NextRequest) {
             return
           }
           currentIndex = (index + markets.length) % markets.length;
-          mountWidget(markets[currentIndex]);
+          const nextMarket = markets[currentIndex];
+          if (widget?.getAttribute('market') !== nextMarket) {
+            mountWidget(nextMarket);
+          }
         }
 
         function rotate(step) {

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -232,6 +232,7 @@ export default function HeaderDropdownUserMenuAuth() {
           sideOffset={0}
           collisionPadding={16}
           portalled={isMobile}
+          positionMethod="fixed"
         >
           <DropdownMenuItem render={<UserInfoSection />} />
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -8,7 +8,7 @@ import { cn } from '@/lib/utils'
 
 type DropdownMenuPositionerProps = Pick<
   DropdownMenuPrimitive.Positioner.Props,
-  'align' | 'alignOffset' | 'collisionPadding' | 'side' | 'sideOffset'
+  'align' | 'alignOffset' | 'collisionPadding' | 'positionMethod' | 'side' | 'sideOffset'
 >
 
 type DropdownMenuContentProps = DropdownMenuPrimitive.Popup.Props &
@@ -36,6 +36,7 @@ function DropdownMenuContent({
   className,
   collisionPadding,
   portalled = true,
+  positionMethod,
   side = 'bottom',
   sideOffset = 4,
   ...props
@@ -46,6 +47,7 @@ function DropdownMenuContent({
       align={align}
       alignOffset={alignOffset}
       collisionPadding={collisionPadding}
+      positionMethod={positionMethod}
       side={side}
       sideOffset={sideOffset}
       className="isolate z-50 outline-none"

--- a/src/hooks/useAffiliateOrderMetadata.ts
+++ b/src/hooks/useAffiliateOrderMetadata.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { ZERO_ADDRESS } from '@/lib/contracts'
+import { useUser } from '@/stores/useUser'
 
 interface AffiliateInfoResponse {
   referrerAddress: `0x${string}`
@@ -10,12 +11,23 @@ interface AffiliateInfoResponse {
   builderMakerFlatFeeBps: number
 }
 
+export interface AffiliateOrderMetadata extends AffiliateInfoResponse {
+  isLoading: boolean
+}
+
 const DEFAULT_RESPONSE: AffiliateInfoResponse = {
   referrerAddress: ZERO_ADDRESS,
   affiliateAddress: ZERO_ADDRESS,
   affiliateSharePercent: 0,
   builderTakerFeeShareBps: 3000,
   builderMakerFlatFeeBps: 0,
+}
+
+export function getAffiliateOrderMetadataQueryKey(
+  userId: string | null | undefined,
+  referredByUserId: string | null | undefined,
+) {
+  return ['affiliate-order-info', userId ?? 'guest', referredByUserId ?? null] as const
 }
 
 async function fetchAffiliateInfo(): Promise<AffiliateInfoResponse> {
@@ -33,13 +45,17 @@ async function fetchAffiliateInfo(): Promise<AffiliateInfoResponse> {
   return response.json()
 }
 
-export function useAffiliateOrderMetadata(): AffiliateInfoResponse {
-  const { data } = useQuery({
-    queryKey: ['affiliate-order-info'],
+export function useAffiliateOrderMetadata(): AffiliateOrderMetadata {
+  const user = useUser()
+  const { data, isLoading } = useQuery({
+    queryKey: getAffiliateOrderMetadataQueryKey(user?.id, user?.referred_by_user_id),
     queryFn: fetchAffiliateInfo,
     staleTime: 'static',
     gcTime: 10 * 60 * 1000,
   })
 
-  return data ?? DEFAULT_RESPONSE
+  return {
+    ...(data ?? DEFAULT_RESPONSE),
+    isLoading,
+  }
 }

--- a/src/lib/affiliate-referral.ts
+++ b/src/lib/affiliate-referral.ts
@@ -1,0 +1,11 @@
+export type ReferralSetupStatus = 'not-required' | 'checking' | 'required' | 'configured'
+
+export function resolveReferralSetupStatus(results: Array<boolean | null>): ReferralSetupStatus {
+  if (results.some((result) => result !== true)) {
+    return 'required'
+  }
+  if (results.length > 0 && results.every((result) => result === true)) {
+    return 'configured'
+  }
+  return 'not-required'
+}

--- a/src/lib/affiliate-referral.ts
+++ b/src/lib/affiliate-referral.ts
@@ -1,5 +1,10 @@
 export type ReferralSetupStatus = 'not-required' | 'checking' | 'required' | 'configured'
 
+export interface ReferralExchangeReadResult<T> {
+  exchangesToConfigure: T[]
+  fullyChecked: boolean
+}
+
 export function resolveReferralSetupStatus(results: Array<boolean | null>): ReferralSetupStatus {
   if (results.some((result) => result !== true)) {
     return 'required'
@@ -8,4 +13,14 @@ export function resolveReferralSetupStatus(results: Array<boolean | null>): Refe
     return 'configured'
   }
   return 'not-required'
+}
+
+export function resolveReferralExchangeReads<T>(
+  exchanges: readonly T[],
+  results: Array<boolean | null>,
+): ReferralExchangeReadResult<T> {
+  return {
+    exchangesToConfigure: exchanges.filter((_, index) => results[index] === false),
+    fullyChecked: results.length === exchanges.length && results.every((result) => result !== null),
+  }
 }

--- a/src/lib/data-api/fees.ts
+++ b/src/lib/data-api/fees.ts
@@ -4,6 +4,7 @@ export interface FeeReceiverTotal {
   exchange: string
   receiver: string
   tokenId: string
+  feeType?: FeeHistoryType
   totalAmount: string
   totalVolume: string
   updatedAt: number
@@ -30,6 +31,7 @@ export interface FeeHistoryTimeSeries {
 interface FeeReceiverTotalsParams {
   endpoint: 'referrers'
   address: string
+  feeType?: FeeHistoryType
   exchange?: string
   tokenId?: string
   limit?: number
@@ -39,6 +41,7 @@ interface FeeReceiverTotalsParams {
 export async function fetchFeeReceiverTotals({
   endpoint,
   address,
+  feeType,
   exchange,
   tokenId,
   limit = 100,
@@ -46,6 +49,9 @@ export async function fetchFeeReceiverTotals({
 }: FeeReceiverTotalsParams): Promise<FeeReceiverTotal[]> {
   const params = new URLSearchParams()
   params.set('address', normalizeDataApiAddress(address))
+  if (feeType) {
+    params.set('feeType', feeType)
+  }
   if (exchange) {
     params.set('exchange', normalizeDataApiAddress(exchange))
   }
@@ -142,24 +148,21 @@ export function combineAvailableDailyFeeSeries(
   return combineDailyFeeSeries(availableSeries, now)
 }
 
-export function sumFeeTotals(totals: FeeReceiverTotal[]): bigint {
-  return totals.reduce((acc, total) => {
-    try {
-      return acc + BigInt(total.totalAmount)
-    } catch {
-      return acc
-    }
-  }, 0n)
+function parseDecimalFeeValue(value: string): number {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : 0
 }
 
-export function sumFeeVolumes(totals: FeeReceiverTotal[]): bigint {
+export function sumFeeTotals(totals: FeeReceiverTotal[]): number {
   return totals.reduce((acc, total) => {
-    try {
-      return acc + BigInt(total.totalVolume)
-    } catch {
-      return acc
-    }
-  }, 0n)
+    return acc + parseDecimalFeeValue(total.totalAmount)
+  }, 0)
+}
+
+export function sumFeeVolumes(totals: FeeReceiverTotal[]): number {
+  return totals.reduce((acc, total) => {
+    return acc + parseDecimalFeeValue(total.totalVolume)
+  }, 0)
 }
 
 export function baseUnitsToNumber(amount: bigint, decimals = 6): number {

--- a/src/lib/embed-widget.ts
+++ b/src/lib/embed-widget.ts
@@ -1,4 +1,4 @@
-const EMBED_SCRIPT_URL = 'https://unpkg.com/@kuestcom/embeds/dist/index.js'
+const EMBED_SCRIPT_URL = 'https://unpkg.com/@kuestcom/embeds@1.3.12/dist/embeds/market/index.js'
 
 type EmbedTheme = 'light' | 'dark'
 const CUSTOM_ELEMENT_NAME_PATTERN = /^[a-z](?:[a-z0-9-]*[a-z0-9])?$/
@@ -49,6 +49,7 @@ export function buildIframeSrc(
   }
 
   const params = new URLSearchParams({ market: marketSlug, theme })
+  params.set('transparent', 'true')
   if (features.length > 0) {
     params.set('features', features.join(','))
   }
@@ -63,6 +64,7 @@ export function buildPreviewSrc(marketSlug: string, theme: EmbedTheme, features:
   }
 
   const params = new URLSearchParams({ market: marketSlug, theme })
+  params.set('transparent', 'true')
   if (features.length > 0) {
     params.set('features', features.join(','))
   }
@@ -124,6 +126,7 @@ export function buildWebComponentCode(
     lines.push(`\t\taffiliate="${safeAffiliateCode}"`)
   }
 
+  lines.push('\t\ttransparent')
   lines.push(`\t\ttheme="${safeTheme}"`)
   lines.push('\t/>')
   lines.push('</div>')

--- a/tests/unit/DropdownMenu.test.tsx
+++ b/tests/unit/DropdownMenu.test.tsx
@@ -17,7 +17,7 @@ describe('DropdownMenu', () => {
     render(
       <DropdownMenu>
         <DropdownMenuTrigger>Open menu</DropdownMenuTrigger>
-        <DropdownMenuContent portalled={false}>
+        <DropdownMenuContent portalled={false} positionMethod="fixed">
           <DropdownMenuItem>Menu item</DropdownMenuItem>
           <DropdownMenuItem render={<button type="button" />} nativeButton>
             Button item
@@ -40,6 +40,9 @@ describe('DropdownMenu', () => {
     expect(screen.getByRole('menuitem', { name: 'Button item' }).tagName).toBe('BUTTON')
     expect(screen.getByRole('menuitemradio', { name: 'English' })).toBeVisible()
     expect(screen.getByRole('menuitemradio', { name: 'Portuguese' })).toBeVisible()
+    expect(
+      screen.getByRole('menuitem', { name: 'Menu item' }).closest('[data-slot="dropdown-menu-content"]')?.parentElement,
+    ).toHaveStyle({ position: 'fixed' })
   })
 
   it('closes after clicking a navigation item', async () => {

--- a/tests/unit/affiliateOrderMetadata.test.ts
+++ b/tests/unit/affiliateOrderMetadata.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest'
+
+import { getAffiliateOrderMetadataQueryKey } from '@/hooks/useAffiliateOrderMetadata'
+
+describe('affiliate order metadata query key', () => {
+  it('changes when an anonymous visitor signs in through a referral', () => {
+    const anonymousKey = getAffiliateOrderMetadataQueryKey(null, null)
+    const referredUserKey = getAffiliateOrderMetadataQueryKey('user-1', 'affiliate-1')
+
+    expect(anonymousKey).not.toEqual(referredUserKey)
+    expect(referredUserKey).toEqual(['affiliate-order-info', 'user-1', 'affiliate-1'])
+  })
+})

--- a/tests/unit/affiliateReferral.test.ts
+++ b/tests/unit/affiliateReferral.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveReferralSetupStatus } from '@/lib/affiliate-referral'
+
+describe('affiliate referral setup', () => {
+  it('requires setup while any exchange remains unlocked', () => {
+    expect(resolveReferralSetupStatus([true, false])).toBe('required')
+  })
+
+  it('is configured only when every exchange is locked', () => {
+    expect(resolveReferralSetupStatus([true, true])).toBe('configured')
+  })
+
+  it('keeps setup required when an exchange cannot be read', () => {
+    expect(resolveReferralSetupStatus([true, null])).toBe('required')
+  })
+})

--- a/tests/unit/affiliateReferral.test.ts
+++ b/tests/unit/affiliateReferral.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveReferralSetupStatus } from '@/lib/affiliate-referral'
+import { resolveReferralExchangeReads, resolveReferralSetupStatus } from '@/lib/affiliate-referral'
 
 describe('affiliate referral setup', () => {
   it('requires setup while any exchange remains unlocked', () => {
@@ -13,5 +13,19 @@ describe('affiliate referral setup', () => {
 
   it('keeps setup required when an exchange cannot be read', () => {
     expect(resolveReferralSetupStatus([true, null])).toBe('required')
+  })
+
+  it('keeps normal approvals available while retrying unknown referral exchanges', () => {
+    expect(resolveReferralExchangeReads(['standard', 'neg-risk'], [false, null])).toEqual({
+      exchangesToConfigure: ['standard'],
+      fullyChecked: false,
+    })
+  })
+
+  it('confirms referral reads only after every exchange responds', () => {
+    expect(resolveReferralExchangeReads(['standard', 'neg-risk'], [true, false])).toEqual({
+      exchangesToConfigure: ['neg-risk'],
+      fullyChecked: true,
+    })
   })
 })

--- a/tests/unit/dataApiFees.test.ts
+++ b/tests/unit/dataApiFees.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { FeeReceiverTotal } from '@/lib/data-api/fees'
+
+import { fetchFeeReceiverTotals, sumFeeTotals, sumFeeVolumes } from '@/lib/data-api/fees'
+
+function total(totalAmount: string, totalVolume: string): FeeReceiverTotal {
+  return {
+    exchange: '0xexchange',
+    receiver: '0xreceiver',
+    tokenId: '0',
+    feeType: 'AFFILIATE',
+    totalAmount,
+    totalVolume,
+    updatedAt: 0,
+  }
+}
+
+describe('Data API fee receiver totals', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('requests totals filtered to affiliate fee events', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify([])))
+
+    await fetchFeeReceiverTotals({ endpoint: 'referrers', address: '0xABC', feeType: 'AFFILIATE' })
+
+    const requestInput = fetchMock.mock.calls[0][0]
+    const requestUrl = new URL(
+      typeof requestInput === 'string'
+        ? requestInput
+        : requestInput instanceof URL
+          ? requestInput.href
+          : requestInput.url,
+    )
+    expect(requestUrl.searchParams.get('address')).toBe('0xabc')
+    expect(requestUrl.searchParams.get('feeType')).toBe('AFFILIATE')
+  })
+
+  it('sums decimal USDC amounts without discarding them', () => {
+    const totals = [total('0.430515', '32.8795'), total('5.274777', '757.671261')]
+
+    expect(sumFeeTotals(totals)).toBeCloseTo(5.705292, 6)
+    expect(sumFeeVolumes(totals)).toBeCloseTo(790.550761, 6)
+  })
+
+  it('ignores malformed values and normalizes floating-point dust', () => {
+    const totals = [total('invalid', 'invalid'), total('-4.5083985915177205e-14', '10')]
+
+    expect(sumFeeTotals(totals)).toBeCloseTo(0, 6)
+    expect(sumFeeVolumes(totals)).toBe(10)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Repairs affiliate rewards totals and the referral setup flow, and fixes header user menu positioning on mobile. Market embeds are now theme-aware with transparent backgrounds; trading approvals respect referral locks but continue when some exchanges can’t be read, and affiliate numbers use precise decimal amounts filtered to `AFFILIATE` events.

- **Bug Fixes**
  - Accurate affiliate rewards: totals/volume now sum decimal amounts and filter to `AFFILIATE`; settings/admin pages updated; `fetchFeeReceiverTotals` accepts `feeType`; `sumFeeTotals`/`sumFeeVolumes` return numbers; settings page uses `fetchFeeHistoryTotal` for fees.
  - Referral setup gating: onboarding checks referral metadata and exchange lock status; doesn’t block approvals while status is “checking” or when some exchanges are unreadable; configures known exchanges and retries unknown ones; blocks only when setup is required.
  - Stable affiliate metadata: query key depends on user and referrer; hook exposes `isLoading` to coordinate onboarding.
  - User menu positioning: `DropdownMenuContent` supports `positionMethod="fixed"` and is applied to auth/guest menus to prevent clipping.
  - Tests cover fee filtering/sums, partial referral read handling, referral setup resolution, metadata query key changes, and fixed positioning.

- **New Features**
  - Themeable embeds: generated embeds adopt the site theme, support `transparent` backgrounds, and include inline CSS vars; dialogs default to the current theme; embed URLs/markup updated and `@kuestcom/embeds@1.3.12` is used.

<sup>Written for commit 531712c20a028aa7da85766e29c613828496ecf8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

