### PR TITLE
fix: restore embed theme contrast

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -198,6 +198,7 @@ function useEmbedCodeBuilders({
       attributeLine('\t', 'width', '400'),
       attributeLine('\t', 'height', String(iframeHeight)),
       attributeLine('\t', 'frameBorder', '0'),
+      attributeLine('\t', 'style', 'border-radius: 12px; background: transparent'),
       tagSelfCloseLine(''),
     ]
   }, [embedIframeTitle, iframeSrc, iframeHeight])
@@ -227,7 +228,6 @@ function useEmbedCodeBuilders({
       lines.push(attributeLine('\t\t', 'affiliate', affiliateCode))
     }
 
-    lines.push(attributeLine('\t\t', 'transparent', ''))
     lines.push(attributeLine('\t\t', 'theme', theme))
     lines.push(tagSelfCloseLine('\t'))
     lines.push(tagCloseLine('', 'div'))
@@ -494,7 +494,7 @@ function EventChartEmbedDialogEditor({
             title={t('Embed preview')}
             src={previewSrc}
             style={{ height: `${iframeHeight}px` }}
-            className="w-full max-w-[400px] border-0 bg-transparent"
+            className="w-full max-w-[400px] overflow-hidden rounded-[12px] border-0 bg-transparent"
           />
         </div>
       </div>

--- a/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
@@ -77,7 +77,6 @@ function buildAffiliateIframeSrc(
   const params = new URLSearchParams({
     category: categorySlug,
     theme,
-    transparent: 'true',
     rotate: 'true',
     locale,
   })
@@ -106,7 +105,6 @@ function buildAffiliatePreviewSrc(
   const params = new URLSearchParams({
     category: categorySlug,
     theme,
-    transparent: 'true',
     rotate: 'true',
     locale,
   })
@@ -335,6 +333,7 @@ function useEmbedCode({
       attributeLine('\t', 'width', '400'),
       attributeLine('\t', 'height', String(iframeHeight)),
       attributeLine('\t', 'frameBorder', '0'),
+      attributeLine('\t', 'style', 'border-radius: 12px; background: transparent'),
       tagSelfCloseLine(''),
     ],
     [embedIframeTitle, iframeSrc, iframeHeight],
@@ -365,7 +364,6 @@ function useEmbedCode({
       lines.push(attributeLine('\t\t', 'affiliate', affiliateCode))
     }
 
-    lines.push(attributeLine('\t\t', 'transparent', ''))
     lines.push(attributeLine('\t\t', 'theme', theme))
     lines.push(tagSelfCloseLine('\t'))
     lines.push(tagCloseLine('', 'div'))
@@ -588,7 +586,7 @@ export default function AffiliateWidgetDialog({ open, onOpenChange, categories }
               title={t('Embed preview')}
               src={previewSrc}
               style={{ height: `${iframeHeight}px` }}
-              className="w-100 max-w-full border-0 bg-transparent"
+              className="w-100 max-w-full overflow-hidden rounded-[12px] border-0 bg-transparent"
             />
           ) : (
             <p className="px-4 text-center text-sm text-muted-foreground">

--- a/src/lib/embed-widget.ts
+++ b/src/lib/embed-widget.ts
@@ -49,7 +49,6 @@ export function buildIframeSrc(
   }
 
   const params = new URLSearchParams({ market: marketSlug, theme })
-  params.set('transparent', 'true')
   if (features.length > 0) {
     params.set('features', features.join(','))
   }
@@ -64,7 +63,6 @@ export function buildPreviewSrc(marketSlug: string, theme: EmbedTheme, features:
   }
 
   const params = new URLSearchParams({ market: marketSlug, theme })
-  params.set('transparent', 'true')
   if (features.length > 0) {
     params.set('features', features.join(','))
   }
@@ -84,6 +82,7 @@ export function buildIframeCode(src: string, height: number, iframeTitle: string
     '\twidth="400"',
     `\theight="${height}"`,
     '\tframeBorder="0"',
+    '\tstyle="border-radius: 12px; background: transparent"',
     '/>',
   ].join('\n')
 }
@@ -126,7 +125,6 @@ export function buildWebComponentCode(
     lines.push(`\t\taffiliate="${safeAffiliateCode}"`)
   }
 
-  lines.push('\t\ttransparent')
   lines.push(`\t\ttheme="${safeTheme}"`)
   lines.push('\t/>')
   lines.push('</div>')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore embed theme contrast by removing forced transparency and applying explicit transparent backgrounds via iframe styles. Also adds rounded corners and consistent preview styling.

- **Bug Fixes**
  - Removed `transparent` param/attribute from embed URLs and web component code.
  - Added iframe `style="border-radius: 12px; background: transparent"` in generated embed code.
  - Updated preview iframes to use rounded corners and overflow-hidden for clean edges.
  - Ensures theme colors render with proper contrast in event and affiliate embeds.

<sup>Written for commit 848cefda51b67e1999e7e613fa1c7417598403e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

