### PR TITLE
fix: improve trade notification layout

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -176,7 +176,7 @@ globalThis.addEventListener('push', (event) => {
       }
       await globalThis.registration.showNotification(alert.message, {
         body: alert.market_title,
-        icon: alert.icon || '/images/pwa/default-icon-192.png',
+        icon: alert.trader_avatar || alert.icon || '/images/pwa/default-icon-192.png',
         badge: alert.badge || alert.icon || '/images/pwa/default-icon-192.png',
         image: alert.market_icon || undefined,
         tag: alert.notification_id,

--- a/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
@@ -12,6 +12,11 @@ import { useEffect, useRef } from 'react'
 import type { Notification } from '@/types'
 
 import EventIconImage, { isEventMarketIconUrl } from '@/components/EventIconImage'
+import {
+  FollowedTradeAvatar,
+  FollowedTradeMarketContext,
+  FollowedTradeSummary,
+} from '@/components/FollowedTradeNotification'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
@@ -106,6 +111,32 @@ function isLocalMergeNotification(notification: Notification) {
 
 function isFollowedTradeNotification(notification: Notification) {
   return notification.metadata?.source === 'followed_trade'
+}
+
+function followedTradeDetails(notification: Notification) {
+  if (!isFollowedTradeNotification(notification)) {
+    return null
+  }
+  const metadata = notification.metadata ?? {}
+  const trader = typeof metadata.trader === 'string' ? metadata.trader : ''
+  const side = typeof metadata.side === 'string' ? metadata.side : ''
+  const outcome = typeof metadata.outcome === 'string' ? metadata.outcome : ''
+  if (!trader || !side || !outcome) {
+    return null
+  }
+  return {
+    trader,
+    side,
+    outcome,
+    followedWallet: typeof metadata.followedWallet === 'string' ? metadata.followedWallet : trader,
+    averagePrice: typeof metadata.averagePrice === 'number' ? metadata.averagePrice : null,
+    totalValue: typeof metadata.totalValue === 'number' ? metadata.totalValue : null,
+    eventTitle:
+      typeof metadata.eventTitle === 'string' && metadata.eventTitle.trim()
+        ? metadata.eventTitle
+        : notification.description,
+    eventIcon: typeof metadata.eventIcon === 'string' ? metadata.eventIcon : null,
+  }
 }
 
 function getWheelLineHeight(element: HTMLElement) {
@@ -299,6 +330,7 @@ export default function HeaderNotifications() {
                 const timeLabel = getNotificationTimeLabel(notification, currentTimestamp)
                 const hasLink = Boolean(notification.link_url)
                 const isFollowedTrade = isFollowedTradeNotification(notification)
+                const followedTrade = followedTradeDetails(notification)
                 const isLocalOrderFill = isLocalOrderFillNotification(notification) || isFollowedTrade
                 const isLocalMerge = isLocalMergeNotification(notification)
                 const linkIsExternal =
@@ -309,7 +341,23 @@ export default function HeaderNotifications() {
                   <ExternalLinkIcon className={cn('size-3 text-muted-foreground', { 'opacity-0': !hasLink })} />
                 )
                 const avatarUrl = notification.user_avatar?.trim() ?? ''
-                const avatarContent = isLocalMerge ? (
+                const avatarContent = followedTrade ? (
+                  <FollowedTradeAvatar
+                    trader={followedTrade.trader}
+                    wallet={followedTrade.followedWallet}
+                    src={avatarUrl}
+                  />
+                ) : isFollowedTrade ? (
+                  <FollowedTradeAvatar
+                    trader={notification.title}
+                    wallet={
+                      typeof notification.metadata?.followedWallet === 'string'
+                        ? notification.metadata.followedWallet
+                        : notification.id
+                    }
+                    src={avatarUrl}
+                  />
+                ) : isLocalMerge ? (
                   <div
                     aria-hidden="true"
                     className={cn(
@@ -368,10 +416,30 @@ export default function HeaderNotifications() {
                     <div className="min-w-0 flex-1">
                       <div className="mb-1 flex items-start justify-between gap-2">
                         <div className="min-w-0 flex-1">
-                          <h4 className="text-sm/tight font-semibold text-foreground">{notification.title}</h4>
-                          <p className="mt-1 line-clamp-2 text-xs/tight text-muted-foreground">
-                            {notification.description}
-                          </p>
+                          {followedTrade ? (
+                            <>
+                              <FollowedTradeSummary
+                                trader={followedTrade.trader}
+                                side={followedTrade.side}
+                                outcome={followedTrade.outcome}
+                                averagePrice={followedTrade.averagePrice}
+                                totalValue={followedTrade.totalValue}
+                                className="block pr-1"
+                              />
+                              <FollowedTradeMarketContext
+                                eventTitle={followedTrade.eventTitle}
+                                eventIcon={followedTrade.eventIcon}
+                                className="mt-1"
+                              />
+                            </>
+                          ) : (
+                            <>
+                              <h4 className="text-sm/tight font-semibold text-foreground">{notification.title}</h4>
+                              <p className="mt-1 line-clamp-2 text-xs/tight text-muted-foreground">
+                                {notification.description}
+                              </p>
+                            </>
+                          )}
                         </div>
 
                         <div className="flex shrink-0 items-center gap-1">

--- a/src/components/FollowedTradeNotification.tsx
+++ b/src/components/FollowedTradeNotification.tsx
@@ -1,0 +1,128 @@
+'use client'
+
+import { useExtracted } from 'next-intl'
+import Image from 'next/image'
+
+import EventIconImage from '@/components/EventIconImage'
+import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
+import { getAvatarPlaceholderStyle, shouldUseAvatarPlaceholder } from '@/lib/avatar'
+import { formatDollarValueLabel, formatSharePriceLabel } from '@/lib/formatters'
+import { cn } from '@/lib/utils'
+
+interface FollowedTradeSummaryProps {
+  trader: string
+  side: string
+  outcome: string
+  averagePrice?: number | null
+  totalValue?: number | null
+  className?: string
+}
+
+interface FollowedTradeMarketContextProps {
+  eventTitle: string
+  eventIcon?: string | null
+  className?: string
+}
+
+interface FollowedTradeAvatarProps {
+  trader: string
+  wallet: string
+  src?: string | null
+  size?: number
+  className?: string
+}
+
+function resolveTradeAlertImageUrl(value?: string | null) {
+  const normalized = value?.trim() ?? ''
+  if (!normalized) {
+    return null
+  }
+  if (normalized.startsWith('http://') || normalized.startsWith('https://') || normalized.startsWith('/')) {
+    return normalized
+  }
+  return `https://gateway.irys.xyz/${normalized}`
+}
+
+export function resolveTradeAlertOutcomeColorClass(outcome?: string | null) {
+  const normalized = outcome?.trim().toLowerCase() ?? ''
+  return normalized.includes('yes') || normalized.includes('up') || normalized.includes('true') ? 'text-yes' : 'text-no'
+}
+
+export function FollowedTradeSummary({
+  trader,
+  side,
+  outcome,
+  averagePrice,
+  totalValue,
+  className,
+}: FollowedTradeSummaryProps) {
+  const t = useExtracted()
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const normalizedOutcome = normalizeOutcomeLabel(outcome) || outcome
+  const priceLabel =
+    typeof averagePrice === 'number' && Number.isFinite(averagePrice)
+      ? formatSharePriceLabel(averagePrice, { fallback: '' })
+      : ''
+  const totalLabel =
+    typeof totalValue === 'number' && Number.isFinite(totalValue) && totalValue > 0
+      ? formatDollarValueLabel(totalValue, { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+      : ''
+
+  return (
+    <span className={cn('min-w-0 text-sm/tight', className)}>
+      <span className="font-semibold text-foreground">{trader}</span>{' '}
+      <span className="text-muted-foreground">{side.toUpperCase() === 'SELL' ? t('sold') : t('bought')}</span>{' '}
+      <span className={cn('font-semibold', resolveTradeAlertOutcomeColorClass(outcome))}>{normalizedOutcome}</span>
+      {priceLabel && (
+        <>
+          {' '}
+          <span className="text-muted-foreground">
+            {t('at')} {priceLabel}
+          </span>
+        </>
+      )}
+      {totalLabel && <span className="text-muted-foreground"> ({totalLabel})</span>}
+    </span>
+  )
+}
+
+export function FollowedTradeMarketContext({ eventTitle, eventIcon, className }: FollowedTradeMarketContextProps) {
+  const resolvedIcon = resolveTradeAlertImageUrl(eventIcon)
+  return (
+    <span className={cn('flex min-w-0 items-center gap-1.5 text-xs/tight text-muted-foreground', className)}>
+      {resolvedIcon && (
+        <EventIconImage
+          src={resolvedIcon}
+          alt=""
+          sizes="16px"
+          containerClassName="size-4 shrink-0 rounded-[3px] bg-muted"
+        />
+      )}
+      <span className="line-clamp-2 min-w-0">{eventTitle}</span>
+    </span>
+  )
+}
+
+export function FollowedTradeAvatar({ trader, wallet, src, size = 42, className }: FollowedTradeAvatarProps) {
+  const avatarUrl = resolveTradeAlertImageUrl(src)
+  const showPlaceholder = shouldUseAvatarPlaceholder(avatarUrl)
+  const dimensions = { width: size, height: size }
+  if (showPlaceholder) {
+    return (
+      <span
+        aria-hidden="true"
+        className={cn('block shrink-0 rounded-full border border-border/80', className)}
+        style={{ ...getAvatarPlaceholderStyle(wallet || trader), ...dimensions }}
+      />
+    )
+  }
+  return (
+    <Image
+      src={avatarUrl!}
+      alt={trader}
+      width={size}
+      height={size}
+      className={cn('shrink-0 rounded-full border border-border/80 object-cover object-center', className)}
+    />
+  )
+}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -16,6 +16,7 @@ interface ToastData {
   content?: ReactNode
   icon?: ReactNode
   image?: ReactNode
+  onClick?: () => void
 }
 
 interface ToastActionOptions {
@@ -31,6 +32,7 @@ interface ToastOptions {
   icon?: ReactNode
   id?: number | string
   image?: ReactNode
+  onClick?: () => void
 }
 
 interface ToastFunction {
@@ -48,7 +50,7 @@ interface ToastFunction {
 const toastManager = ToastPrimitive.createToastManager<ToastData>()
 
 function showToast(type: ToastType, title: ReactNode, options: ToastOptions = {}) {
-  const { action, content, description, duration, icon, id, image } = options
+  const { action, content, description, duration, icon, id, image, onClick } = options
 
   return toastManager.add({
     actionProps: action
@@ -57,7 +59,7 @@ function showToast(type: ToastType, title: ReactNode, options: ToastOptions = {}
           onClick: action.onClick,
         }
       : undefined,
-    data: { content, icon, image },
+    data: { content, icon, image, onClick },
     description,
     id: id === undefined ? undefined : String(id),
     priority: type === 'error' || type === 'warning' ? 'high' : 'low',
@@ -133,7 +135,13 @@ function ToastContent({ className, ...props }: ToastPrimitive.Content.Props) {
 }
 
 function ToastTitle({ className, ...props }: ToastPrimitive.Title.Props) {
-  return <ToastPrimitive.Title data-slot="toast-title" className={cn('text-base font-medium', className)} {...props} />
+  return (
+    <ToastPrimitive.Title
+      data-slot="toast-title"
+      className={cn('line-clamp-2 min-w-0 text-base font-medium break-words', className)}
+      {...props}
+    />
+  )
 }
 
 function ToastDescription({ className, ...props }: ToastPrimitive.Description.Props) {
@@ -141,7 +149,7 @@ function ToastDescription({ className, ...props }: ToastPrimitive.Description.Pr
     <ToastPrimitive.Description
       data-slot="toast-description"
       render={<div />}
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn('min-w-0 text-sm break-words text-muted-foreground', className)}
       {...props}
     />
   )
@@ -175,7 +183,7 @@ function ToastClose({ className, children, ...props }: ToastPrimitive.Close.Prop
   )
 }
 
-function DefaultToastIcon({ type }: { type: string | undefined }) {
+function defaultToastIcon(type: string | undefined) {
   if (type === 'success') {
     return <CircleCheckIcon className="size-5 text-yes" />
   }
@@ -199,10 +207,42 @@ function ToastList() {
 
   return toasts.map((toastItem) => {
     const customContent = toastItem.data?.content
-    const icon = toastItem.data?.icon ?? <DefaultToastIcon type={toastItem.type} />
+    const icon = toastItem.data?.icon ?? defaultToastIcon(toastItem.type)
+    const onClick = toastItem.data?.onClick
 
     return (
-      <Toast key={toastItem.id} toast={toastItem}>
+      <Toast
+        key={toastItem.id}
+        toast={toastItem}
+        className={cn(onClick && 'cursor-pointer transition-colors hover:bg-accent/50')}
+        role={onClick ? 'link' : undefined}
+        tabIndex={onClick ? 0 : undefined}
+        onClick={
+          onClick
+            ? (event) => {
+                const interactiveTarget =
+                  event.target instanceof Element
+                    ? event.target.closest('a,button,[role="button"],[role="link"]')
+                    : null
+                if (event.defaultPrevented || (interactiveTarget && interactiveTarget !== event.currentTarget)) {
+                  return
+                }
+                onClick()
+              }
+            : undefined
+        }
+        onKeyDown={
+          onClick
+            ? (event) => {
+                if (event.target !== event.currentTarget || (event.key !== 'Enter' && event.key !== ' ')) {
+                  return
+                }
+                event.preventDefault()
+                onClick()
+              }
+            : undefined
+        }
+      >
         <ToastContent>
           {toastItem.data?.image}
           {icon && (

--- a/src/lib/trade-alerts.ts
+++ b/src/lib/trade-alerts.ts
@@ -9,14 +9,19 @@ export interface TradeAlertPayload {
   message: string
   market_title: string
   market_icon?: string | null
+  event_title?: string | null
+  event_icon?: string | null
   icon?: string | null
   badge?: string | null
   url: string
   created_at: string
   expires_at: string
   trader?: string
+  trader_avatar?: string | null
   side?: 'BUY' | 'SELL' | 'buy' | 'sell'
   shares?: number
+  average_price?: number
+  total_value?: number
   outcome?: string | null
 }
 
@@ -104,17 +109,24 @@ export function parseTradeAlertPayload(value: unknown, options: { origin: string
     message,
     market_title: marketTitle,
     market_icon: typeof value.market_icon === 'string' ? value.market_icon : null,
+    event_title: typeof value.event_title === 'string' ? value.event_title : null,
+    event_icon: typeof value.event_icon === 'string' ? value.event_icon : null,
     icon: typeof value.icon === 'string' ? value.icon : null,
     badge: typeof value.badge === 'string' ? value.badge : null,
     url: resolveTradeAlertUrl(rawUrl, options.origin),
     created_at: createdAt,
     expires_at: expiresAt,
     trader: typeof value.trader === 'string' ? value.trader : undefined,
+    trader_avatar: typeof value.trader_avatar === 'string' ? value.trader_avatar : null,
     side:
       value.side === 'BUY' || value.side === 'SELL' || value.side === 'buy' || value.side === 'sell'
         ? value.side
         : undefined,
     shares: typeof value.shares === 'number' && Number.isFinite(value.shares) ? value.shares : undefined,
+    average_price:
+      typeof value.average_price === 'number' && Number.isFinite(value.average_price) ? value.average_price : undefined,
+    total_value:
+      typeof value.total_value === 'number' && Number.isFinite(value.total_value) ? value.total_value : undefined,
     outcome: typeof value.outcome === 'string' ? value.outcome : null,
   }
 

--- a/src/providers/TradeAlertsProvider.tsx
+++ b/src/providers/TradeAlertsProvider.tsx
@@ -5,6 +5,11 @@ import type { ReactNode } from 'react'
 import { useExtracted, useLocale } from 'next-intl'
 import { useEffect, useRef, useState } from 'react'
 
+import {
+  FollowedTradeAvatar,
+  FollowedTradeMarketContext,
+  FollowedTradeSummary,
+} from '@/components/FollowedTradeNotification'
 import { toast } from '@/components/ui/toast'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { detachTradeAlertsBeforeLogout } from '@/hooks/useTradeAlerts'
@@ -180,13 +185,38 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
           return
         }
         useTradeAlertsStore.getState().prependAlert(result.alert)
-        toast.info(payload.message, {
-          id: payload.notification_id,
-          action: {
-            label: payload.market_title,
+        const hasStructuredSummary = Boolean(payload.trader && payload.side && payload.outcome)
+        toast.message(
+          hasStructuredSummary ? (
+            <FollowedTradeSummary
+              trader={payload.trader!}
+              side={payload.side!}
+              outcome={payload.outcome!}
+              averagePrice={payload.average_price}
+              totalValue={payload.total_value}
+            />
+          ) : (
+            payload.message
+          ),
+          {
+            id: payload.notification_id,
+            description: (
+              <FollowedTradeMarketContext
+                eventTitle={payload.event_title || payload.market_title}
+                eventIcon={payload.event_icon || payload.market_icon}
+              />
+            ),
+            image: (
+              <FollowedTradeAvatar
+                trader={payload.trader || payload.followed_wallet}
+                wallet={payload.followed_wallet}
+                src={payload.trader_avatar}
+                size={40}
+              />
+            ),
             onClick: () => window.location.assign(payload.url),
           },
-        })
+        )
       }
 
       function handleServiceWorkerMessage(event: MessageEvent) {

--- a/src/stores/useNotifications.ts
+++ b/src/stores/useNotifications.ts
@@ -185,7 +185,7 @@ function tradeAlertNotifications(alerts: ReturnType<typeof useTradeAlertsStore.g
     title: alert.message,
     description: alert.market_title,
     created_at: alert.created_at,
-    user_avatar: alert.market_icon,
+    user_avatar: alert.trader_avatar,
     link_type: 'market',
     link_target: new URL(alert.url).pathname + new URL(alert.url).search,
     link_url: alert.url,
@@ -195,6 +195,13 @@ function tradeAlertNotifications(alerts: ReturnType<typeof useTradeAlertsStore.g
       read: alert.read,
       followedWallet: alert.followed_wallet,
       conditionId: alert.condition_id,
+      trader: alert.trader,
+      side: alert.side,
+      outcome: alert.outcome,
+      averagePrice: alert.average_price,
+      totalValue: alert.total_value,
+      eventTitle: alert.event_title || alert.market_title,
+      eventIcon: alert.event_icon || alert.market_icon,
     },
   }))
 }

--- a/tests/unit/FollowedTradeNotification.test.tsx
+++ b/tests/unit/FollowedTradeNotification.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  FollowedTradeAvatar,
+  FollowedTradeMarketContext,
+  FollowedTradeSummary,
+  resolveTradeAlertOutcomeColorClass,
+} from '@/components/FollowedTradeNotification'
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (message: string) => message,
+}))
+
+describe('FollowedTradeNotification', () => {
+  it('renders the compact activity-style trade summary', () => {
+    render(<FollowedTradeSummary trader="m.maverick" side="BUY" outcome="Yes" averagePrice={0.9} totalValue={30} />)
+
+    expect(screen.getByText('m.maverick')).toHaveClass('font-semibold')
+    expect(screen.getByText('Yes')).toHaveClass('font-semibold', 'text-yes')
+    expect(screen.getByText(/at 90¢/)).toBeVisible()
+    expect(screen.getByText(/\(\$30\)/)).toBeVisible()
+  })
+
+  it('uses red for negative outcomes and renders compact event context', () => {
+    expect(resolveTradeAlertOutcomeColorClass('No')).toBe('text-no')
+    render(<FollowedTradeMarketContext eventTitle="Will the White House call a full lid?" eventIcon="/event.png" />)
+    expect(screen.getByText('Will the White House call a full lid?')).toHaveClass('line-clamp-2')
+  })
+
+  it('shows a deterministic round placeholder without a profile photo', () => {
+    const { container } = render(<FollowedTradeAvatar trader="m.maverick" wallet="0xabc" />)
+    expect(container.firstElementChild).toHaveClass('rounded-full')
+    expect(container.firstElementChild).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/tests/unit/Toast.test.tsx
+++ b/tests/unit/Toast.test.tsx
@@ -59,4 +59,28 @@ describe('Toast', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Undo' }))
     expect(onAction).toHaveBeenCalledOnce()
   })
+
+  it('supports an entirely clickable toast without making its close button navigate', async () => {
+    const onClick = vi.fn()
+    render(<Toaster />)
+
+    act(() => {
+      toast.message('Bruno bought 3.33 Up', {
+        description: 'Bitcoin Up or Down',
+        onClick,
+      })
+    })
+
+    const clickableToast = await screen.findByRole('link', { name: 'Bruno bought 3.33 Up' })
+    fireEvent.click(clickableToast)
+    expect(onClick).toHaveBeenCalledOnce()
+
+    fireEvent.keyDown(clickableToast, { key: 'Enter' })
+    expect(onClick).toHaveBeenCalledTimes(2)
+
+    const closeButton = document.querySelector<HTMLButtonElement>('[data-slot="toast-close"]')
+    expect(closeButton).not.toBeNull()
+    fireEvent.click(closeButton!)
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
 })

--- a/tests/unit/serviceWorkerTradeAlerts.test.ts
+++ b/tests/unit/serviceWorkerTradeAlerts.test.ts
@@ -7,6 +7,7 @@ describe('trade alert service worker', () => {
   it('uses the deterministic notification id for operating-system deduplication', () => {
     expect(source).toContain('tag: alert.notification_id')
     expect(source).toContain('renotify: false')
+    expect(source).toContain('icon: alert.trader_avatar || alert.icon')
   })
 
   it('does not show native notifications while a visible client can display the toast', () => {

--- a/tests/unit/tradeAlerts.test.tsx
+++ b/tests/unit/tradeAlerts.test.tsx
@@ -14,6 +14,15 @@ function payload(overrides: Record<string, unknown> = {}) {
     message: 'Bruno bought 420 YES in Market',
     market_title: 'Market',
     market_icon: '/market.png',
+    event_title: 'Event',
+    event_icon: '/event.png',
+    trader: 'Bruno',
+    trader_avatar: '/bruno.png',
+    side: 'BUY',
+    shares: 420,
+    average_price: 0.9,
+    total_value: 378,
+    outcome: 'YES',
     url: `${origin}/event/example/market`,
     created_at: new Date(now - 1_000).toISOString(),
     expires_at: new Date(now + 14 * 60_000).toISOString(),
@@ -30,6 +39,10 @@ describe('trade alert validation', () => {
       followed_wallet: '0xabc',
       condition_id: '0xdef',
       url: `${origin}/event/example/market`,
+      trader_avatar: '/bruno.png',
+      average_price: 0.9,
+      total_value: 378,
+      event_title: 'Event',
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves layout and accessibility of followed trade notifications across the app and push. Previously we showed generic text with a market icon; now we render a compact trader-focused summary with avatar and event context, and make toasts fully clickable. Push notifications now prefer the trader avatar for the icon.

- In-app toasts: render `FollowedTradeSummary` as the title and `FollowedTradeMarketContext` as the description; show a `FollowedTradeAvatar`; make the entire toast clickable via `onClick` with keyboard support; clamp and wrap long text; fall back to the legacy message if required fields are missing.
- Header notifications: detect followed trade notifications and show the same summary/context and avatar; fall back to the legacy title/description when data is incomplete; use a deterministic placeholder when no avatar is available.
- Trade alert payloads: parse and store optional `event_title`, `event_icon`, `trader_avatar`, `average_price`, and `total_value`; OS notifications use `trader_avatar` when present; no breaking changes. Producers can include these fields to enable the richer layout.
- Tests: add coverage for the new components, clickable toast behavior, and service worker icon preference.

<sup>Written for commit d6bb25606d96e47dcdd3e4b72cf7fd4a98097ac0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

