### PR TITLE
feat: add notifications integration

### DIFF
--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -7,6 +7,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   AlertTriangleIcon,
   ArrowLeftRightIcon,
+  BellIcon,
   CalendarClockIcon,
   CalendarIcon,
   CheckCircle2Icon,
@@ -36,10 +37,19 @@ import MarketMakingCampaigns from '@/app/[locale]/admin/market-making/_component
 import MarketMakingHowItWorks from '@/app/[locale]/admin/market-making/_components/MarketMakingHowItWorks'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
-import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
 import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Switch } from '@/components/ui/switch'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { toast } from '@/components/ui/toast'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
@@ -47,6 +57,12 @@ import { useIsMobile } from '@/hooks/useIsMobile'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { COLLATERAL_TOKEN_ADDRESS, MARKET_MAKER_ESCROW_ADDRESS, POLY_SYNCER_CREATOR_ADDRESS } from '@/lib/contracts'
+import {
+  linkSponsorEmail,
+  NotificationApiError,
+  readNotificationSettings,
+  updateNotificationSettings,
+} from '@/lib/kuest-notifications'
 import { MARKET_MAKER_ESCROW_ABI } from '@/lib/market-maker-escrow'
 import { cn } from '@/lib/utils'
 import { resolveViemNetworkByChainId } from '@/lib/viem-network'
@@ -133,6 +149,15 @@ interface MarketMakingCopy {
   importFailed: string
   importRefundable: string
   importPaymentPending: string
+  notificationSettings: string
+  emailAddress: string
+  emailDescription: string
+  continueToSign: string
+  verify: string
+  verifying: string
+  verificationUnavailable: string
+  saveChanges: string
+  marketMaking: string
 }
 
 interface MarketMakingDiscoveryProps {
@@ -813,6 +838,75 @@ function ImportProgressModal({
   )
 }
 
+function SponsorEmailDialog({
+  copy,
+  open,
+  email,
+  pending,
+  verificationPending,
+  error,
+  onEmailChange,
+  onOpenChange,
+  onSubmit,
+  onVerified,
+}: {
+  copy: MarketMakingCopy
+  open: boolean
+  email: string
+  pending: boolean
+  verificationPending: boolean
+  error: string | null
+  onEmailChange: (email: string) => void
+  onOpenChange: (open: boolean) => void
+  onSubmit: () => void
+  onVerified: () => void
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{copy.emailAddress}</DialogTitle>
+          <DialogDescription>{copy.emailDescription}</DialogDescription>
+        </DialogHeader>
+        {!verificationPending ? (
+          <div className="space-y-2">
+            <Label htmlFor="market-making-sponsor-email">{copy.emailAddress}</Label>
+            <Input
+              id="market-making-sponsor-email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => onEmailChange(event.target.value)}
+              disabled={pending}
+            />
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">{copy.verify}</p>
+        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
+        <DialogFooter>
+          <Button
+            type="button"
+            disabled={pending || (!verificationPending && !email.trim())}
+            onClick={verificationPending ? onVerified : onSubmit}
+          >
+            {pending ? (
+              <>
+                <LoaderCircleIcon className="size-4 animate-spin" />
+                {copy.verifying}
+              </>
+            ) : verificationPending ? (
+              copy.verify
+            ) : (
+              copy.continueToSign
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
 function CampaignDialog({
   item,
   locale,
@@ -832,7 +926,7 @@ function CampaignDialog({
   const { address, isConnected } = appKitAccount
   const { walletProvider, walletProviderType } = useAppKitProvider<RpcWalletProvider>('eip155')
   const { chainId: appKitChainId, switchNetwork } = useAppKitNetwork()
-  const { chainId, escrowUrl } = usePublicRuntimeConfig()
+  const { chainId, escrowUrl, notificationsUrl } = usePublicRuntimeConfig()
   const { data: walletClient } = useWalletClient()
   const publicClient = usePublicClient({ chainId })
   const queryClient = useQueryClient()
@@ -943,6 +1037,11 @@ function CampaignDialog({
   const [importOpen, setImportOpen] = useState(false)
   const [isRetryingImport, setIsRetryingImport] = useState(false)
   const [readyNotified, setReadyNotified] = useState(false)
+  const [emailDialogOpen, setEmailDialogOpen] = useState(false)
+  const [notificationEmail, setNotificationEmail] = useState('')
+  const [emailLinkPending, setEmailLinkPending] = useState(false)
+  const [emailVerificationPending, setEmailVerificationPending] = useState(false)
+  const [emailLinkError, setEmailLinkError] = useState<string | null>(null)
   const importStorageKey =
     address && item.slug ? `kuest-market-import:${chainId}:${address.toLowerCase()}:${item.slug}` : null
   const importPaymentStorageKey = importStorageKey ? `${importStorageKey}:payment` : null
@@ -1117,6 +1216,48 @@ function CampaignDialog({
     } finally {
       setIsRetryingImport(false)
     }
+  }
+
+  async function handleLinkSponsorEmail() {
+    if (!address || !transactionWalletClient) {
+      setEmailLinkError(copy.walletNotReady)
+      return
+    }
+    setEmailLinkPending(true)
+    setEmailLinkError(null)
+    try {
+      await ensureWalletNetwork()
+      const result = await runWithSignaturePrompt(
+        () =>
+          linkSponsorEmail({
+            notificationsUrl,
+            wallet: address as `0x${string}`,
+            walletClient: transactionWalletClient,
+            email: notificationEmail,
+            locale,
+            siteDomain: window.location.hostname.toLowerCase(),
+          }),
+        { title: copy.emailAddress, description: copy.transactionPrompt },
+      )
+      if (result.alreadyVerified) {
+        setEmailDialogOpen(false)
+        setEmailVerificationPending(false)
+        await handleFundCampaign()
+        return
+      }
+      setEmailVerificationPending(true)
+    } catch (error) {
+      setEmailLinkError(
+        error instanceof NotificationApiError ? copy.verificationUnavailable : fundingErrorMessage(error, copy),
+      )
+    } finally {
+      setEmailLinkPending(false)
+    }
+  }
+
+  async function handleEmailVerified() {
+    setEmailDialogOpen(false)
+    await handleFundCampaign()
   }
 
   async function handleFundCampaign() {
@@ -1335,8 +1476,18 @@ function CampaignDialog({
       toast.success(copy.campaignCreated)
       onOpenChange(false)
     } catch (error) {
+      if (error instanceof EscrowApiError && error.code === 'verified_email_required') {
+        setIssueError(null)
+        setEmailLinkError(null)
+        setEmailDialogOpen(true)
+        return
+      }
       const friendlyMessage =
-        error instanceof EscrowApiError ? quoteErrorMessage(error, copy) : fundingErrorMessage(error, copy)
+        error instanceof EscrowApiError && error.code === 'notifications_unavailable'
+          ? copy.verificationUnavailable
+          : error instanceof EscrowApiError
+            ? quoteErrorMessage(error, copy)
+            : fundingErrorMessage(error, copy)
       setIssueError(friendlyMessage)
       if (!isUserRejectedRequestError(error)) {
         console.error('Failed to fund market-making campaign.', error)
@@ -1650,6 +1801,18 @@ function CampaignDialog({
           onOpenChange={setImportOpen}
           onRetry={handleRetryImport}
         />
+        <SponsorEmailDialog
+          copy={copy}
+          open={emailDialogOpen}
+          email={notificationEmail}
+          pending={emailLinkPending}
+          verificationPending={emailVerificationPending}
+          error={emailLinkError}
+          onEmailChange={setNotificationEmail}
+          onOpenChange={setEmailDialogOpen}
+          onSubmit={() => void handleLinkSponsorEmail()}
+          onVerified={() => void handleEmailVerified()}
+        />
       </>
     )
   }
@@ -1673,6 +1836,154 @@ function CampaignDialog({
         onOpenChange={setImportOpen}
         onRetry={handleRetryImport}
       />
+      <SponsorEmailDialog
+        copy={copy}
+        open={emailDialogOpen}
+        email={notificationEmail}
+        pending={emailLinkPending}
+        verificationPending={emailVerificationPending}
+        error={emailLinkError}
+        onEmailChange={setNotificationEmail}
+        onOpenChange={setEmailDialogOpen}
+        onSubmit={() => void handleLinkSponsorEmail()}
+        onVerified={() => void handleEmailVerified()}
+      />
+    </>
+  )
+}
+
+function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
+  const { address, isConnected } = useAppKitAccount()
+  const { data: walletClient } = useWalletClient()
+  const { chainId, notificationsUrl } = usePublicRuntimeConfig()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [emailVerified, setEmailVerified] = useState(false)
+  const [maskedEmail, setMaskedEmail] = useState<string | null>(null)
+  const [campaignStatus, setCampaignStatus] = useState(true)
+  const [newOpportunities, setNewOpportunities] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  async function loadSettings() {
+    setOpen(true)
+    setError(null)
+    if (!isConnected || !address || !walletClient) {
+      setError(copy.walletNotReady)
+      return
+    }
+    setLoading(true)
+    try {
+      const settings = await runWithSignaturePrompt(
+        () =>
+          readNotificationSettings({
+            notificationsUrl,
+            chainId,
+            wallet: address as `0x${string}`,
+            walletClient,
+          }),
+        { title: copy.notificationSettings, description: copy.transactionPrompt },
+      )
+      setEmailVerified(settings.emailVerified)
+      setMaskedEmail(settings.maskedEmail ?? null)
+      const campaignPreference = settings.preferences?.find(
+        (preference) => preference.channel === 'email' && preference.topic === 'campaign_status',
+      )
+      const opportunityPreference = settings.preferences?.find(
+        (preference) => preference.channel === 'email' && preference.topic === 'new_opportunities',
+      )
+      setCampaignStatus(campaignPreference?.enabled ?? true)
+      setNewOpportunities(opportunityPreference?.enabled ?? true)
+    } catch {
+      setError(copy.verificationUnavailable)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function saveSettings() {
+    if (!address || !walletClient || !emailVerified) {
+      return
+    }
+    setSaving(true)
+    setError(null)
+    try {
+      await runWithSignaturePrompt(
+        () =>
+          updateNotificationSettings({
+            notificationsUrl,
+            chainId,
+            wallet: address as `0x${string}`,
+            walletClient,
+            preferences: [
+              { channel: 'email', topic: 'campaign_status', enabled: campaignStatus },
+              { channel: 'email', topic: 'new_opportunities', enabled: newOpportunities },
+            ],
+          }),
+        { title: copy.notificationSettings, description: copy.transactionPrompt },
+      )
+      setOpen(false)
+    } catch {
+      setError(copy.verificationUnavailable)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        aria-label={copy.notificationSettings}
+        onClick={() => void loadSettings()}
+      >
+        <BellIcon className="size-4" />
+      </Button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{copy.notificationSettings}</DialogTitle>
+            <DialogDescription>{maskedEmail ?? copy.emailDescription}</DialogDescription>
+          </DialogHeader>
+          {loading ? (
+            <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+              <LoaderCircleIcon className="size-4 animate-spin" />
+              {copy.verifying}
+            </div>
+          ) : emailVerified ? (
+            <div className="space-y-4">
+              <div className="flex items-center justify-between gap-4">
+                <Label htmlFor="campaign-status-notifications">{copy.campaignsTab}</Label>
+                <Switch
+                  id="campaign-status-notifications"
+                  checked={campaignStatus}
+                  onCheckedChange={setCampaignStatus}
+                />
+              </div>
+              <div className="flex items-center justify-between gap-4">
+                <Label htmlFor="opportunity-notifications">{copy.marketMaking}</Label>
+                <Switch
+                  id="opportunity-notifications"
+                  checked={newOpportunities}
+                  onCheckedChange={setNewOpportunities}
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">{copy.emailDescription}</p>
+          )}
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          <DialogFooter>
+            <Button type="button" disabled={!emailVerified || loading || saving} onClick={() => void saveSettings()}>
+              {saving ? <LoaderCircleIcon className="size-4 animate-spin" /> : null}
+              {copy.saveChanges}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }
@@ -1716,14 +2027,17 @@ export default function MarketMakingDiscovery({
   return (
     <section className="min-h-[calc(100dvh-6rem)] min-w-0">
       <Tabs defaultValue="sponsor">
-        <TabsList className="h-10">
-          <TabsTrigger value="sponsor" className="h-8 px-5">
-            {copy.sponsorTab}
-          </TabsTrigger>
-          <TabsTrigger value="campaigns" className="h-8 px-5">
-            {copy.campaignsTab}
-          </TabsTrigger>
-        </TabsList>
+        <div className="flex items-center justify-between gap-3">
+          <TabsList className="h-10">
+            <TabsTrigger value="sponsor" className="h-8 px-5">
+              {copy.sponsorTab}
+            </TabsTrigger>
+            <TabsTrigger value="campaigns" className="h-8 px-5">
+              {copy.campaignsTab}
+            </TabsTrigger>
+          </TabsList>
+          <NotificationSettingsButton copy={copy} />
+        </div>
 
         <TabsContent value="sponsor" className="mt-5">
           <div className="relative rounded-3xl border bg-card px-5 py-10 sm:px-10 sm:py-14">

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -21,7 +21,7 @@ import {
   SearchIcon,
   XIcon,
 } from 'lucide-react'
-import { useDeferredValue, useEffect, useMemo, useState } from 'react'
+import { useDeferredValue, useEffect, useMemo, useRef, useState } from 'react'
 import { createWalletClient, custom, encodeFunctionData, erc20Abi } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 
@@ -1043,6 +1043,7 @@ function CampaignDialog({
   const [emailLinkPending, setEmailLinkPending] = useState(false)
   const [emailVerificationPending, setEmailVerificationPending] = useState(false)
   const [emailLinkError, setEmailLinkError] = useState<string | null>(null)
+  const emailLinkRequestId = useRef(0)
   const importStorageKey =
     address && item.slug ? `kuest-market-import:${chainId}:${address.toLowerCase()}:${item.slug}` : null
   const importPaymentStorageKey = importStorageKey ? `${importStorageKey}:payment` : null
@@ -1224,6 +1225,7 @@ function CampaignDialog({
       setEmailLinkError(copy.walletNotReady)
       return
     }
+    const requestId = ++emailLinkRequestId.current
     setEmailLinkPending(true)
     setEmailLinkError(null)
     try {
@@ -1240,6 +1242,9 @@ function CampaignDialog({
           }),
         { title: copy.emailAddress, description: copy.transactionPrompt },
       )
+      if (emailLinkRequestId.current !== requestId) {
+        return
+      }
       if (result.alreadyVerified) {
         setEmailDialogOpen(false)
         setEmailVerificationPending(false)
@@ -1248,11 +1253,16 @@ function CampaignDialog({
       }
       setEmailVerificationPending(true)
     } catch (error) {
+      if (emailLinkRequestId.current !== requestId) {
+        return
+      }
       setEmailLinkError(
         error instanceof NotificationApiError ? copy.verificationUnavailable : fundingErrorMessage(error, copy),
       )
     } finally {
-      setEmailLinkPending(false)
+      if (emailLinkRequestId.current === requestId) {
+        setEmailLinkPending(false)
+      }
     }
   }
 
@@ -1265,6 +1275,8 @@ function CampaignDialog({
   function handleEmailDialogOpenChange(nextOpen: boolean) {
     setEmailDialogOpen(nextOpen)
     if (!nextOpen) {
+      emailLinkRequestId.current += 1
+      setEmailLinkPending(false)
       setEmailVerificationPending(false)
       setEmailLinkError(null)
     }
@@ -1876,7 +1888,11 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
   const [campaignStatus, setCampaignStatus] = useState(true)
   const [newOpportunities, setNewOpportunities] = useState(true)
   const [nonEmailPreferences, setNonEmailPreferences] = useState<NotificationPreference[]>([])
+  const [settingsWallet, setSettingsWallet] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const settingsRequestId = useRef(0)
+  const activeAddress = useRef(address)
+  activeAddress.current = address
   const signingWalletClient = useMemo(() => {
     if (!address) {
       return null
@@ -1894,13 +1910,18 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
       transport: custom(walletProvider),
     })
   }, [address, chainId, walletClient, walletProvider])
+  const hasCurrentSettings = Boolean(address) && emailVerified && settingsWallet === address?.toLowerCase()
 
   async function loadSettings() {
+    const requestId = ++settingsRequestId.current
+    const requestWallet = address?.toLowerCase() ?? null
     setOpen(true)
     setError(null)
     setEmailVerified(false)
     setMaskedEmail(null)
     setNonEmailPreferences([])
+    setSettingsWallet(null)
+    setLoading(false)
     if (!isConnected || !address || !signingWalletClient) {
       setError(copy.walletNotReady)
       return
@@ -1917,6 +1938,9 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
           }),
         { title: copy.notificationSettings, description: copy.transactionPrompt },
       )
+      if (settingsRequestId.current !== requestId || activeAddress.current?.toLowerCase() !== requestWallet) {
+        return
+      }
       setEmailVerified(settings.emailVerified)
       setMaskedEmail(settings.maskedEmail ?? null)
       const campaignPreference = settings.preferences?.find(
@@ -1926,17 +1950,23 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
         (preference) => preference.channel === 'email' && preference.topic === 'new_opportunities',
       )
       setNonEmailPreferences(settings.preferences?.filter((preference) => preference.channel !== 'email') ?? [])
+      setSettingsWallet(requestWallet)
       setCampaignStatus(campaignPreference?.enabled ?? true)
       setNewOpportunities(opportunityPreference?.enabled ?? true)
     } catch {
-      setError(copy.verificationUnavailable)
+      if (settingsRequestId.current === requestId && activeAddress.current?.toLowerCase() === requestWallet) {
+        setError(copy.verificationUnavailable)
+      }
     } finally {
-      setLoading(false)
+      if (settingsRequestId.current === requestId) {
+        setLoading(false)
+      }
     }
   }
 
   async function saveSettings() {
-    if (!address || !signingWalletClient || !emailVerified) {
+    if (!address || !signingWalletClient || !hasCurrentSettings) {
+      setError(copy.walletNotReady)
       return
     }
     setSaving(true)
@@ -1987,7 +2017,7 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
               <LoaderCircleIcon className="size-4 animate-spin" />
               {copy.verifying}
             </div>
-          ) : emailVerified ? (
+          ) : hasCurrentSettings ? (
             <div className="space-y-4">
               <div className="flex items-center justify-between gap-4">
                 <Label htmlFor="campaign-status-notifications">{copy.campaignsTab}</Label>
@@ -2011,7 +2041,11 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
           )}
           {error && <p className="text-sm text-destructive">{error}</p>}
           <DialogFooter>
-            <Button type="button" disabled={!emailVerified || loading || saving} onClick={() => void saveSettings()}>
+            <Button
+              type="button"
+              disabled={!hasCurrentSettings || loading || saving}
+              onClick={() => void saveSettings()}
+            >
               {saving ? <LoaderCircleIcon className="size-4 animate-spin" /> : null}
               {copy.saveChanges}
             </Button>

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -60,6 +60,7 @@ import { COLLATERAL_TOKEN_ADDRESS, MARKET_MAKER_ESCROW_ADDRESS, POLY_SYNCER_CREA
 import {
   linkSponsorEmail,
   NotificationApiError,
+  type NotificationPreference,
   readNotificationSettings,
   updateNotificationSettings,
 } from '@/lib/kuest-notifications'
@@ -1257,7 +1258,16 @@ function CampaignDialog({
 
   async function handleEmailVerified() {
     setEmailDialogOpen(false)
+    setEmailVerificationPending(false)
     await handleFundCampaign()
+  }
+
+  function handleEmailDialogOpenChange(nextOpen: boolean) {
+    setEmailDialogOpen(nextOpen)
+    if (!nextOpen) {
+      setEmailVerificationPending(false)
+      setEmailLinkError(null)
+    }
   }
 
   async function handleFundCampaign() {
@@ -1809,7 +1819,7 @@ function CampaignDialog({
           verificationPending={emailVerificationPending}
           error={emailLinkError}
           onEmailChange={setNotificationEmail}
-          onOpenChange={setEmailDialogOpen}
+          onOpenChange={handleEmailDialogOpenChange}
           onSubmit={() => void handleLinkSponsorEmail()}
           onVerified={() => void handleEmailVerified()}
         />
@@ -1844,7 +1854,7 @@ function CampaignDialog({
         verificationPending={emailVerificationPending}
         error={emailLinkError}
         onEmailChange={setNotificationEmail}
-        onOpenChange={setEmailDialogOpen}
+        onOpenChange={handleEmailDialogOpenChange}
         onSubmit={() => void handleLinkSponsorEmail()}
         onVerified={() => void handleEmailVerified()}
       />
@@ -1854,6 +1864,7 @@ function CampaignDialog({
 
 function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
   const { address, isConnected } = useAppKitAccount()
+  const { walletProvider } = useAppKitProvider<RpcWalletProvider>('eip155')
   const { data: walletClient } = useWalletClient()
   const { chainId, notificationsUrl } = usePublicRuntimeConfig()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
@@ -1864,12 +1875,33 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
   const [maskedEmail, setMaskedEmail] = useState<string | null>(null)
   const [campaignStatus, setCampaignStatus] = useState(true)
   const [newOpportunities, setNewOpportunities] = useState(true)
+  const [nonEmailPreferences, setNonEmailPreferences] = useState<NotificationPreference[]>([])
   const [error, setError] = useState<string | null>(null)
+  const signingWalletClient = useMemo(() => {
+    if (!address) {
+      return null
+    }
+    if (walletClient?.account?.address?.toLowerCase() === address.toLowerCase()) {
+      return walletClient
+    }
+    const chain = resolveViemNetworkByChainId(chainId)
+    if (!chain || !isRpcWalletProvider(walletProvider)) {
+      return null
+    }
+    return createWalletClient({
+      account: address as `0x${string}`,
+      chain,
+      transport: custom(walletProvider),
+    })
+  }, [address, chainId, walletClient, walletProvider])
 
   async function loadSettings() {
     setOpen(true)
     setError(null)
-    if (!isConnected || !address || !walletClient) {
+    setEmailVerified(false)
+    setMaskedEmail(null)
+    setNonEmailPreferences([])
+    if (!isConnected || !address || !signingWalletClient) {
       setError(copy.walletNotReady)
       return
     }
@@ -1881,7 +1913,7 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
             notificationsUrl,
             chainId,
             wallet: address as `0x${string}`,
-            walletClient,
+            walletClient: signingWalletClient,
           }),
         { title: copy.notificationSettings, description: copy.transactionPrompt },
       )
@@ -1893,6 +1925,7 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
       const opportunityPreference = settings.preferences?.find(
         (preference) => preference.channel === 'email' && preference.topic === 'new_opportunities',
       )
+      setNonEmailPreferences(settings.preferences?.filter((preference) => preference.channel !== 'email') ?? [])
       setCampaignStatus(campaignPreference?.enabled ?? true)
       setNewOpportunities(opportunityPreference?.enabled ?? true)
     } catch {
@@ -1903,7 +1936,7 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
   }
 
   async function saveSettings() {
-    if (!address || !walletClient || !emailVerified) {
+    if (!address || !signingWalletClient || !emailVerified) {
       return
     }
     setSaving(true)
@@ -1915,8 +1948,9 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
             notificationsUrl,
             chainId,
             wallet: address as `0x${string}`,
-            walletClient,
+            walletClient: signingWalletClient,
             preferences: [
+              ...nonEmailPreferences,
               { channel: 'email', topic: 'campaign_status', enabled: campaignStatus },
               { channel: 'email', topic: 'new_opportunities', enabled: newOpportunities },
             ],

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -1044,10 +1044,22 @@ function CampaignDialog({
   const [emailVerificationPending, setEmailVerificationPending] = useState(false)
   const [emailLinkError, setEmailLinkError] = useState<string | null>(null)
   const emailLinkRequestId = useRef(0)
+  const activeEmailWallet = useRef(address)
   const importStorageKey =
     address && item.slug ? `kuest-market-import:${chainId}:${address.toLowerCase()}:${item.slug}` : null
   const importPaymentStorageKey = importStorageKey ? `${importStorageKey}:payment` : null
   const [pendingImportPaymentHash, setPendingImportPaymentHash] = useState<string | null>(null)
+
+  useEffect(() => {
+    activeEmailWallet.current = address
+    emailLinkRequestId.current += 1
+    setEmailLinkPending(false)
+    setEmailVerificationPending(false)
+    return () => {
+      emailLinkRequestId.current += 1
+    }
+  }, [address])
+
   const quoteInput = useMemo(
     () => ({
       sponsor: address ?? '',
@@ -1226,10 +1238,14 @@ function CampaignDialog({
       return
     }
     const requestId = ++emailLinkRequestId.current
+    const requestWallet = address.toLowerCase()
     setEmailLinkPending(true)
     setEmailLinkError(null)
     try {
       await ensureWalletNetwork()
+      if (emailLinkRequestId.current !== requestId || activeEmailWallet.current?.toLowerCase() !== requestWallet) {
+        return
+      }
       const result = await runWithSignaturePrompt(
         () =>
           linkSponsorEmail({
@@ -1242,7 +1258,7 @@ function CampaignDialog({
           }),
         { title: copy.emailAddress, description: copy.transactionPrompt },
       )
-      if (emailLinkRequestId.current !== requestId) {
+      if (emailLinkRequestId.current !== requestId || activeEmailWallet.current?.toLowerCase() !== requestWallet) {
         return
       }
       if (result.alreadyVerified) {
@@ -1253,7 +1269,7 @@ function CampaignDialog({
       }
       setEmailVerificationPending(true)
     } catch (error) {
-      if (emailLinkRequestId.current !== requestId) {
+      if (emailLinkRequestId.current !== requestId || activeEmailWallet.current?.toLowerCase() !== requestWallet) {
         return
       }
       setEmailLinkError(
@@ -1892,7 +1908,17 @@ function NotificationSettingsButton({ copy }: { copy: MarketMakingCopy }) {
   const [error, setError] = useState<string | null>(null)
   const settingsRequestId = useRef(0)
   const activeAddress = useRef(address)
-  activeAddress.current = address
+
+  useEffect(() => {
+    activeAddress.current = address
+    settingsRequestId.current += 1
+    setLoading(false)
+    setSettingsWallet(null)
+    return () => {
+      settingsRequestId.current += 1
+    }
+  }, [address])
+
   const signingWalletClient = useMemo(() => {
     if (!address) {
       return null

--- a/src/app/[locale]/admin/market-making/page.tsx
+++ b/src/app/[locale]/admin/market-making/page.tsx
@@ -86,6 +86,15 @@ export default async function AdminMarketMakingPage() {
         importFailed: t('The import paused before completion. Retry does not require another payment.'),
         importRefundable: t('The import could not be completed. Your payment is eligible for an operational refund.'),
         importPaymentPending: t('Confirm the import payment in your wallet.'),
+        notificationSettings: t('Notification Settings'),
+        emailAddress: t('Email address'),
+        emailDescription: t('Add your email to receive market and trading notifications.'),
+        continueToSign: t('Continue to sign'),
+        verify: t('Verify'),
+        verifying: t('Verifying...'),
+        verificationUnavailable: t('Verification is temporarily unavailable.'),
+        saveChanges: t('Save changes'),
+        marketMaking: t('Market Making'),
       }}
       campaignsCopy={{
         search: t('Search markets or events'),

--- a/src/lib/kuest-notifications.ts
+++ b/src/lib/kuest-notifications.ts
@@ -1,0 +1,205 @@
+import type { WalletClient } from 'viem'
+
+import { keccak256, toHex } from 'viem'
+
+interface NotificationApiErrorBody {
+  error?: string
+}
+
+export class NotificationApiError extends Error {
+  constructor(
+    readonly code: string,
+    message = code,
+  ) {
+    super(message)
+  }
+}
+
+async function notificationJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, init)
+  const body = (await response.json().catch(() => null)) as (T & NotificationApiErrorBody) | null
+  if (!response.ok || !body) {
+    throw new NotificationApiError(body?.error ?? 'notifications_unavailable')
+  }
+  return body
+}
+
+function baseUrl(value: string) {
+  return value.replace(/\/+$/, '')
+}
+
+function stableJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableJson).join(',')}]`
+  }
+  if (value !== null && typeof value === 'object') {
+    return `{${Object.entries(value as Record<string, unknown>)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, entry]) => `${JSON.stringify(key)}:${stableJson(entry)}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function payloadHash(payload: unknown): `0x${string}` {
+  return keccak256(toHex(stableJson(payload)))
+}
+
+async function signWalletAction(input: {
+  notificationsUrl: string
+  chainId: number
+  wallet: `0x${string}`
+  walletClient: WalletClient
+  action: 'read_contact_status' | 'update_preferences'
+  payload: unknown
+}) {
+  const challenge = await notificationJson<{
+    nonce: string
+    expiresAt: number
+  }>(`${baseUrl(input.notificationsUrl)}/v1/me/action-challenge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ wallet: input.wallet, action: input.action }),
+  })
+  const signature = await input.walletClient.signTypedData({
+    account: input.wallet,
+    domain: { name: 'Kuest Notifications', version: '1', chainId: input.chainId },
+    types: {
+      WalletAction: [
+        { name: 'wallet', type: 'address' },
+        { name: 'action', type: 'string' },
+        { name: 'payloadHash', type: 'bytes32' },
+        { name: 'nonce', type: 'string' },
+        { name: 'expiresAt', type: 'uint64' },
+      ],
+    },
+    primaryType: 'WalletAction',
+    message: {
+      wallet: input.wallet,
+      action: input.action,
+      payloadHash: payloadHash(input.payload),
+      nonce: challenge.nonce,
+      expiresAt: BigInt(challenge.expiresAt),
+    },
+  })
+  return { ...challenge, signature }
+}
+
+export async function linkSponsorEmail(input: {
+  notificationsUrl: string
+  wallet: `0x${string}`
+  walletClient: WalletClient
+  email: string
+  locale: string
+  siteDomain: string
+}) {
+  const url = baseUrl(input.notificationsUrl)
+  const email = input.email.trim().toLowerCase()
+  const challenge = await notificationJson<{
+    alreadyVerified: boolean
+    nonce?: string
+    expiresAt?: number
+    typedData?: {
+      domain: { name: string; version: string; chainId: number }
+      types: {
+        LinkEmail: readonly { name: string; type: string }[]
+      }
+      primaryType: 'LinkEmail'
+    }
+  }>(`${url}/v1/me/email/challenge`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      wallet: input.wallet,
+      email,
+      role: 'sponsor',
+      siteDomain: input.siteDomain,
+      locale: input.locale.toLowerCase().startsWith('pt') ? 'pt' : 'en',
+    }),
+  })
+  if (challenge.alreadyVerified) {
+    return { alreadyVerified: true as const }
+  }
+  if (!challenge.nonce || !challenge.expiresAt || !challenge.typedData) {
+    throw new NotificationApiError('invalid_challenge')
+  }
+  const signature = await input.walletClient.signTypedData({
+    account: input.wallet,
+    domain: challenge.typedData.domain,
+    types: challenge.typedData.types,
+    primaryType: challenge.typedData.primaryType,
+    message: {
+      wallet: input.wallet,
+      email,
+      role: 'sponsor',
+      siteDomain: input.siteDomain,
+      nonce: challenge.nonce,
+      expiresAt: BigInt(challenge.expiresAt),
+    },
+  })
+  return notificationJson<{ alreadyVerified: boolean; verificationPending?: boolean; maskedEmail?: string }>(
+    `${url}/v1/me/email/link`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        wallet: input.wallet,
+        email,
+        role: 'sponsor',
+        siteDomain: input.siteDomain,
+        locale: input.locale.toLowerCase().startsWith('pt') ? 'pt' : 'en',
+        nonce: challenge.nonce,
+        expiresAt: challenge.expiresAt,
+        signature,
+      }),
+    },
+  )
+}
+
+export interface NotificationPreference {
+  channel: 'email' | 'telegram'
+  topic: 'campaign_status' | 'new_opportunities'
+  enabled: boolean
+}
+
+export async function readNotificationSettings(input: {
+  notificationsUrl: string
+  chainId: number
+  wallet: `0x${string}`
+  walletClient: WalletClient
+}) {
+  const signed = await signWalletAction({ ...input, action: 'read_contact_status', payload: {} })
+  const params = new URLSearchParams({
+    wallet: input.wallet,
+    nonce: signed.nonce,
+    expiresAt: String(signed.expiresAt),
+    signature: signed.signature,
+  })
+  return notificationJson<{
+    emailVerified: boolean
+    maskedEmail?: string | null
+    preferences?: NotificationPreference[]
+  }>(`${baseUrl(input.notificationsUrl)}/v1/me/contact-status?${params}`)
+}
+
+export async function updateNotificationSettings(input: {
+  notificationsUrl: string
+  chainId: number
+  wallet: `0x${string}`
+  walletClient: WalletClient
+  preferences: NotificationPreference[]
+}) {
+  const payload = { preferences: input.preferences }
+  const signed = await signWalletAction({ ...input, action: 'update_preferences', payload })
+  return notificationJson<{ updated: boolean }>(`${baseUrl(input.notificationsUrl)}/v1/me/preferences`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      wallet: input.wallet,
+      preferences: input.preferences,
+      nonce: signed.nonce,
+      expiresAt: signed.expiresAt,
+      signature: signed.signature,
+    }),
+  })
+}

--- a/src/lib/public-runtime-config.shared.ts
+++ b/src/lib/public-runtime-config.shared.ts
@@ -10,6 +10,7 @@ export interface PublicRuntimeConfig {
   gammaUrl: string
   geoblockUrl: string
   isVercel: string
+  notificationsUrl: string
   chainId: number
   polygonRpcUrl: string
   polymarketGammaUrl: string
@@ -34,6 +35,7 @@ export const defaultPublicRuntimeConfig: PublicRuntimeConfig = {
   gammaUrl: 'https://gamma-api.kuest.com',
   geoblockUrl: 'https://geoblock.kuest.com',
   isVercel: 'false',
+  notificationsUrl: 'https://notifications.kuest.com',
   chainId: AMOY_CHAIN_ID,
   polygonRpcUrl: '',
   polymarketGammaUrl: 'https://gamma-api.polymarket.com',
@@ -65,6 +67,10 @@ export function resolvePublicRuntimeEnv(
     gammaUrl: normalizePublicRuntimeEnvValue(env.GAMMA_URL, defaultPublicRuntimeConfig.gammaUrl),
     geoblockUrl: normalizePublicRuntimeEnvValue(env.GEOBLOCK_URL, defaultPublicRuntimeConfig.geoblockUrl),
     isVercel: env.VERCEL_ENV ? 'true' : 'false',
+    notificationsUrl: normalizePublicRuntimeEnvValue(
+      env.NOTIFICATIONS_URL,
+      defaultPublicRuntimeConfig.notificationsUrl,
+    ),
     chainId: parseNetworkChainId(env.CHAIN_ID, defaultPublicRuntimeConfig.chainId),
     polygonRpcUrl: normalizePublicRuntimeEnvValue(env.POLYGON_RPC_URL),
     polymarketGammaUrl: normalizePublicRuntimeEnvValue(

--- a/tests/unit/publicRuntimeConfig.test.ts
+++ b/tests/unit/publicRuntimeConfig.test.ts
@@ -11,6 +11,7 @@ const RUNTIME_ENV_KEYS_BY_CONFIG_KEY = {
   escrowUrl: 'ESCROW_URL',
   gammaUrl: 'GAMMA_URL',
   geoblockUrl: 'GEOBLOCK_URL',
+  notificationsUrl: 'NOTIFICATIONS_URL',
   chainId: 'CHAIN_ID',
   polygonRpcUrl: 'POLYGON_RPC_URL',
   polymarketGammaUrl: 'POLYMARKET_GAMMA_URL',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a notifications integration so sponsors can link a verified email, manage preferences, and unblock funding when verification is required. Previously funding always proceeded; now it pauses on `verified_email_required` and resumes after verification or when already verified.

- UI and behavior
  - Adds a bell icon to open Notification Settings; shows masked email and provides email-based toggles for campaign status and new opportunities.
  - Opens a link/verify dialog on `verified_email_required`; resumes funding after success; shows a friendly error on `notifications_unavailable`.
  - Prevents stale results: tracks request IDs and active wallet; invalidates in-flight link/settings requests on wallet change and resets state on dialog close.

- API and config
  - Adds `src/lib/kuest-notifications.ts` with `linkSponsorEmail`, `readNotificationSettings`, `updateNotificationSettings`, `NotificationApiError`, and `NotificationPreference`. Reads and updates use wallet-signed typed data challenges (`read_contact_status`, `update_preferences`).
  - Adds `notificationsUrl` to public runtime config via `NOTIFICATIONS_URL` (default `https://notifications.kuest.com`).
  - Required action: set `NOTIFICATIONS_URL` if overriding the default and ensure the notifications service is reachable from clients.

<sup>Written for commit 0df76564b7877d9c1bea8808d384cc079b0a700b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

