### PR TITLE
docs: document polymarket mirror identifiers

### DIFF
--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -3900,6 +3900,10 @@
             "type": "string",
             "description": "Token identifier."
           },
+          "mirror_token_id": {
+            "type": "string",
+            "description": "Polymarket token identifier paired with `t`. Omitted when no mirror token exists."
+          },
           "o": {
             "type": "string",
             "description": "Outcome label."
@@ -3922,6 +3926,10 @@
           "c": {
             "type": "string",
             "description": "Condition identifier for the market."
+          },
+          "mirror_condition_id": {
+            "type": "string",
+            "description": "Polymarket condition identifier paired with `c`. Omitted when the market is not a Polymarket mirror."
           },
           "nr": {
             "type": "boolean",
@@ -5080,6 +5088,28 @@
           }
         }
       },
+      "MirroredSamplingMarketToken": {
+        "type": "object",
+        "required": ["token_id", "outcome", "price", "winner"],
+        "properties": {
+          "token_id": {
+            "type": "string"
+          },
+          "mirror_token_id": {
+            "type": "string",
+            "description": "Polymarket token identifier paired with `token_id`. Omitted when no mirror token exists."
+          },
+          "outcome": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "winner": {
+            "type": "boolean"
+          }
+        }
+      },
       "SamplingMarketRewardRate": {
         "type": "object",
         "required": ["asset_address", "rewards_daily_rate"],
@@ -5170,6 +5200,10 @@
           "condition_id": {
             "type": "string"
           },
+          "mirror_condition_id": {
+            "type": "string",
+            "description": "Polymarket condition identifier paired with `condition_id`. Omitted when the market is not a Polymarket mirror."
+          },
           "question_id": {
             "type": "string",
             "description": "Condition identifier for the market (legacy field name)."
@@ -5230,7 +5264,7 @@
           "tokens": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SamplingMarketToken"
+              "$ref": "#/components/schemas/MirroredSamplingMarketToken"
             }
           },
           "tags": {
@@ -5285,6 +5319,10 @@
             "type": "string",
             "description": "Condition identifier for the market."
           },
+          "mirror_condition_id": {
+            "type": "string",
+            "description": "Polymarket condition identifier paired with `condition_id`. Omitted when the market is not a Polymarket mirror."
+          },
           "status": {
             "type": "string",
             "description": "Market status."
@@ -5322,7 +5360,7 @@
           "tokens": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/SamplingMarketToken"
+              "$ref": "#/components/schemas/MirroredSamplingMarketToken"
             }
           },
           "rewards": {
@@ -5374,13 +5412,25 @@
             "type": "string",
             "description": "Condition identifier for the parent market."
           },
+          "mirror_condition_id": {
+            "type": "string",
+            "description": "Polymarket condition identifier paired with `condition_id`. Omitted when the market is not a Polymarket mirror."
+          },
           "primary_token_id": {
             "type": "string",
             "description": "First token identifier for the market."
           },
+          "mirror_primary_token_id": {
+            "type": "string",
+            "description": "Polymarket token identifier paired with `primary_token_id`. Omitted when no mirror token exists."
+          },
           "secondary_token_id": {
             "type": "string",
             "description": "Second token identifier for the market."
+          },
+          "mirror_secondary_token_id": {
+            "type": "string",
+            "description": "Polymarket token identifier paired with `secondary_token_id`. Omitted when no mirror token exists."
           }
         }
       },

--- a/docs/api-reference/schemas/openapi-gamma.json
+++ b/docs/api-reference/schemas/openapi-gamma.json
@@ -97,6 +97,16 @@
                             "updatedAt": "2026-03-09T22:29:23.723738Z",
                             "requiresTranslation": false
                           }
+                        ],
+                        "markets": [
+                          {
+                            "id": "540900",
+                            "question": "Will the public beta launch before July 31?",
+                            "conditionId": "0x9c1a953fe92c8357f1b646ba25d983aa83e90c525992db14fb726fa895cb5763",
+                            "mirrorConditionId": "0x6f2785e2b184bc654c2925b97d606f4b3b8d0d9d8a7c812ea43689a7d5a0b621",
+                            "clobTokenIds": "[\"8501497159083948713316135768103773293754490207922884688769443031624417212426\", \"2527312495175492857904889758552137141356236738032676480522356889996545113869\"]",
+                            "mirrorClobTokenIds": "[\"73501925031906527019333480630149051764054215203433004184557289228116041007011\", \"34109248701156002295603169775253921334309011282830349017777218896811220437750\"]"
+                          }
                         ]
                       }
                     ]
@@ -214,6 +224,9 @@
             "$ref": "#/components/parameters/ConditionIdParam"
           },
           {
+            "$ref": "#/components/parameters/MirrorParam"
+          },
+          {
             "$ref": "#/components/parameters/SlugQueryParam"
           },
           {
@@ -244,6 +257,7 @@
                         "id": "540900",
                         "question": "Will the public beta launch before July 31?",
                         "conditionId": "0x9c1a953fe92c8357f1b646ba25d983aa83e90c525992db14fb726fa895cb5763",
+                        "mirrorConditionId": "0x6f2785e2b184bc654c2925b97d606f4b3b8d0d9d8a7c812ea43689a7d5a0b621",
                         "slug": "public-beta-before-july-31",
                         "resolutionSource": "",
                         "endDate": "2026-07-31T12:00:00Z",
@@ -253,6 +267,7 @@
                         "description": "This market resolves to \"Yes\" if the company makes its public beta generally available before July 31, 2026, according to its official release page.",
                         "outcomes": "[\"Yes\", \"No\"]",
                         "clobTokenIds": "[\"8501497159083948713316135768103773293754490207922884688769443031624417212426\", \"2527312495175492857904889758552137141356236738032676480522356889996545113869\"]",
+                        "mirrorClobTokenIds": "[\"73501925031906527019333480630149051764054215203433004184557289228116041007011\", \"34109248701156002295603169775253921334309011282830349017777218896811220437750\"]",
                         "active": true,
                         "closed": false,
                         "archived": false,
@@ -1317,6 +1332,14 @@
           "example": "0x9c1a953fe92c8357f1b646ba25d983aa83e90c525992db14fb726fa895cb5763"
         }
       },
+      "MirrorParam": {
+        "name": "mirror",
+        "in": "query",
+        "description": "Filter by Polymarket origin. `true` returns only mirror markets; `false` returns only markets without a Polymarket mirror.",
+        "schema": {
+          "type": "boolean"
+        }
+      },
       "SlugQueryParam": {
         "name": "slug",
         "in": "query",
@@ -1576,6 +1599,10 @@
           "conditionId": {
             "type": "string"
           },
+          "mirrorConditionId": {
+            "type": "string",
+            "description": "Polymarket condition identifier paired with `conditionId`. Omitted when the market is not a Polymarket mirror or the value is unavailable."
+          },
           "slug": {
             "type": "string"
           },
@@ -1604,6 +1631,10 @@
           },
           "clobTokenIds": {
             "type": "string"
+          },
+          "mirrorClobTokenIds": {
+            "type": "string",
+            "description": "JSON-encoded array of Polymarket token identifiers. Each item at index `i` is paired with `clobTokenIds[i]`. Omitted when the market is not a Polymarket mirror or a complete positional token mapping is unavailable."
           },
           "active": {
             "type": "boolean"


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Documents Polymarket mirror identifiers across the CLOB and Gamma API references so clients can map our markets and tokens to their Polymarket counterparts. No API behavior change; all new fields are optional and omitted when not applicable.

- CLOB: add `mirror_token_id` and `mirror_condition_id` (paired with `token_id`/`condition_id`), plus `mirror_primary_token_id` and `mirror_secondary_token_id`. Introduce `MirroredSamplingMarketToken` and reference it where token arrays appear.
- Gamma: add `mirrorConditionId` and `mirrorClobTokenIds` to schemas and examples; add `mirror` query parameter to filter for Polymarket-origin markets.

**Review/Migration**
- If you generate clients from the OpenAPI docs, expect a type name change where `SamplingMarketToken` was referenced to `MirroredSamplingMarketToken`. No request shape changes; the new fields are optional.

<sup>Written for commit aa5eded7293a96aad67cc8bd67131bb56d3a1b37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

