### PR TITLE
feat: open campaigns by ID from search and deep links

### DIFF
--- a/src/app/[locale]/admin/api/market-making/campaigns/route.ts
+++ b/src/app/[locale]/admin/api/market-making/campaigns/route.ts
@@ -88,6 +88,25 @@ async function fetchIndexedCampaigns(url: string): Promise<IndexedCampaignsRespo
   }
 }
 
+async function fetchIndexedCampaign(url: string): Promise<IndexedCampaign | null | 'error'> {
+  try {
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(8_000),
+    })
+    if (response.status === 404) {
+      return null
+    }
+    if (!response.ok) {
+      return 'error'
+    }
+    return (await response.json()) as IndexedCampaign
+  } catch {
+    return 'error'
+  }
+}
+
 function resolveImageUrl(value: string | null | undefined) {
   const normalized = value?.trim()
   if (!normalized) {
@@ -115,7 +134,7 @@ function indexedTerms(value: EscrowTermsValue | undefined) {
   return (value && typeof value === 'object' && !Array.isArray(value) ? value : {}) as IndexedTerms
 }
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
     const currentUser = await UserRepository.getCurrentUser({ minimal: true })
     if (!currentUser || !currentUser.is_admin) {
@@ -127,14 +146,31 @@ export async function GET() {
 
     const { escrowUrl } = resolvePublicRuntimeEnv(process.env)
     const escrowBaseUrl = escrowUrl.replace(/\/+$/, '')
-    const indexedResponse = await fetchIndexedCampaigns(
-      `${escrowBaseUrl}/api/campaigns?sponsor=${encodeURIComponent(currentUser.address)}&limit=100`,
-    )
-    if (!indexedResponse) {
-      return NextResponse.json({ error: 'Campaign index is unavailable.' }, { status: 502 })
+    const campaignId = new URL(request.url).searchParams.get('campaign')
+    let indexedCampaigns: IndexedCampaign[]
+    if (campaignId !== null) {
+      if (!/^(0|[1-9][0-9]*)$/.test(campaignId)) {
+        return NextResponse.json({ error: 'Campaign ID is invalid.' }, { status: 400 })
+      }
+      const indexedCampaign = await fetchIndexedCampaign(
+        `${escrowBaseUrl}/api/campaigns/${encodeURIComponent(campaignId)}`,
+      )
+      if (indexedCampaign === 'error') {
+        return NextResponse.json({ error: 'Campaign index is unavailable.' }, { status: 502 })
+      }
+      if (!indexedCampaign || indexedCampaign.sponsor.toLowerCase() !== currentUser.address.toLowerCase()) {
+        return NextResponse.json({ error: 'Campaign not found.' }, { status: 404 })
+      }
+      indexedCampaigns = [indexedCampaign]
+    } else {
+      const indexedResponse = await fetchIndexedCampaigns(
+        `${escrowBaseUrl}/api/campaigns?sponsor=${encodeURIComponent(currentUser.address)}&limit=100`,
+      )
+      if (!indexedResponse) {
+        return NextResponse.json({ error: 'Campaign index is unavailable.' }, { status: 502 })
+      }
+      indexedCampaigns = indexedResponse.data ?? []
     }
-
-    const indexedCampaigns = indexedResponse.data ?? []
     const conditionIds = [
       ...new Set(
         indexedCampaigns.flatMap((campaign) => campaign.markets.map((market) => market.conditionId.toLowerCase())),

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingCampaigns.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingCampaigns.tsx
@@ -761,7 +761,12 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
   })
   const handledCampaignId = useRef<string | null>(null)
   useEffect(() => {
-    const latestCampaigns = [...(campaignsQuery.data?.data ?? []), ...(campaignLookupQuery.data?.data ?? [])]
+    if (lookupCampaignId) {
+      setSearch(lookupCampaignId)
+    }
+  }, [lookupCampaignId])
+  useEffect(() => {
+    const latestCampaigns = [...(campaignLookupQuery.data?.data ?? []), ...(campaignsQuery.data?.data ?? [])]
     const latestById = new Map(latestCampaigns.map((campaign) => [campaign.id, campaign]))
     setSelected((current) => (current ? (latestById.get(current.id) ?? null) : current))
     setCancelCampaign((current) => (current ? (latestById.get(current.id) ?? null) : current))
@@ -795,7 +800,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
   const campaigns = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase()
     const allCampaigns = new Map<string, MarketMakingCampaignRecord>()
-    for (const campaign of [...(campaignsQuery.data?.data ?? []), ...(campaignLookupQuery.data?.data ?? [])]) {
+    for (const campaign of [...(campaignLookupQuery.data?.data ?? []), ...(campaignsQuery.data?.data ?? [])]) {
       allCampaigns.set(campaign.id, campaign)
     }
     return [...allCampaigns.values()].filter((campaign) => {
@@ -824,11 +829,11 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
   ]
   const pendingWithdrawalAtomic = pendingWithdrawalsQuery.data ?? '0'
   const hasPendingWithdrawal = BigInt(pendingWithdrawalAtomic) > 0n
-  const lookupFoundInCampaigns = Boolean(
-    lookupCampaignId && campaignsQuery.data?.data.some((campaign) => campaign.id === lookupCampaignId),
-  )
-  const isLoading = campaignsQuery.isLoading || (campaignLookupQuery.isLoading && !lookupFoundInCampaigns)
-  const isError = campaignsQuery.isError || (campaignLookupQuery.isError && !lookupFoundInCampaigns)
+  const hasBulkCampaignData = (campaignsQuery.data?.data.length ?? 0) > 0
+  const hasLookupCampaignData = (campaignLookupQuery.data?.data.length ?? 0) > 0
+  const isLoading = campaignsQuery.isLoading || (campaignLookupQuery.isLoading && !hasBulkCampaignData)
+  const isError =
+    (campaignsQuery.isError && !hasLookupCampaignData) || (campaignLookupQuery.isError && !hasBulkCampaignData)
   const reasons: Array<{ id: DisputeReason; label: string }> = [
     { id: 'liquidity_unavailable', label: copy.liquidityUnavailable },
     { id: 'spread_exceeded', label: copy.spreadExceeded },
@@ -836,6 +841,25 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
     { id: 'maker_stopped', label: copy.makerStopped },
     { id: 'other', label: copy.other },
   ]
+
+  function resetCampaignLookup() {
+    handledCampaignId.current = null
+    setLookupId(null)
+    setLinkedCampaignId(null)
+  }
+
+  function closeCampaignDetail() {
+    setSelected(null)
+    resetCampaignLookup()
+  }
+
+  async function refreshCampaignData() {
+    await Promise.all([
+      campaignsQuery.refetch(),
+      pendingWithdrawalsQuery.refetch(),
+      ...(lookupCampaignId ? [campaignLookupQuery.refetch()] : []),
+    ])
+  }
 
   async function writeCampaign(functionName: 'cancelCampaign' | 'openDispute', campaign: MarketMakingCampaignRecord) {
     if (!isConnected || !address || !walletClient) {
@@ -872,7 +896,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
       if (receipt.status !== 'success') {
         throw new Error(copy.transactionFailed)
       }
-      await Promise.all([campaignsQuery.refetch(), pendingWithdrawalsQuery.refetch()])
+      await refreshCampaignData()
       toast.success(functionName === 'cancelCampaign' ? copy.refundReadyToWithdraw : copy.transactionConfirmed)
       return true
     } catch (error) {
@@ -914,7 +938,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
       if (receipt.status !== 'success') {
         throw new Error(copy.transactionFailed)
       }
-      await Promise.all([campaignsQuery.refetch(), pendingWithdrawalsQuery.refetch()])
+      await refreshCampaignData()
       toast.success(copy.transactionConfirmed)
     } catch (error) {
       if (isUserRejectedRequestError(error)) {
@@ -939,7 +963,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
               const value = event.target.value
               setSearch(value)
               if (!/^(0|[1-9][0-9]*)$/.test(value.trim())) {
-                setLookupId(null)
+                resetCampaignLookup()
               }
             }}
             onKeyDown={(event) => {
@@ -1063,7 +1087,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
           locale={locale}
           copy={copy}
           open
-          onOpenChange={(open) => !open && setSelected(null)}
+          onOpenChange={(open) => !open && closeCampaignDetail()}
           onCancel={() => setCancelCampaign(selected)}
           onDispute={() => {
             setDisputeReason(null)
@@ -1092,7 +1116,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
               onClick={async () => {
                 if (cancelCampaign && (await writeCampaign('cancelCampaign', cancelCampaign))) {
                   setCancelCampaign(null)
-                  setSelected(null)
+                  closeCampaignDetail()
                 }
               }}
             >
@@ -1142,7 +1166,7 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
               onClick={async () => {
                 if (disputeCampaign && disputeReason && (await writeCampaign('openDispute', disputeCampaign))) {
                   setDisputeCampaign(null)
-                  setSelected(null)
+                  closeCampaignDetail()
                 }
               }}
             >

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingCampaigns.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingCampaigns.tsx
@@ -15,7 +15,7 @@ import {
   ShieldAlertIcon,
   XIcon,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { formatUnits, keccak256, stringToHex } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 
@@ -714,12 +714,20 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
   const publicClient = usePublicClient({ chainId })
   const [filter, setFilter] = useState<EscrowCampaignStatusFilter>('all')
   const [search, setSearch] = useState('')
+  const [linkedCampaignId, setLinkedCampaignId] = useState<string | null>(null)
+  const [lookupId, setLookupId] = useState<string | null>(null)
   const [selected, setSelected] = useState<MarketMakingCampaignRecord | null>(null)
   const [cancelCampaign, setCancelCampaign] = useState<MarketMakingCampaignRecord | null>(null)
   const [disputeCampaign, setDisputeCampaign] = useState<MarketMakingCampaignRecord | null>(null)
   const [disputeReason, setDisputeReason] = useState<DisputeReason | null>(null)
   const [isMutating, setIsMutating] = useState(false)
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000))
+  useEffect(() => {
+    const value = new URLSearchParams(window.location.search).get('campaign')
+    setLinkedCampaignId(value && /^(0|[1-9][0-9]*)$/.test(value) ? value : null)
+  }, [])
+  const validLinkedCampaignId = linkedCampaignId && /^(0|[1-9][0-9]*)$/.test(linkedCampaignId) ? linkedCampaignId : null
+  const lookupCampaignId = lookupId ?? validLinkedCampaignId
   useEffect(() => {
     const interval = window.setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30_000)
     return () => window.clearInterval(interval)
@@ -736,16 +744,37 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
       return (await response.json()) as MarketMakingCampaignsResponse
     },
   })
+  const campaignLookupQuery = useQuery({
+    queryKey: ['market-making-campaign', lookupCampaignId],
+    enabled: Boolean(lookupCampaignId),
+    queryFn: async () => {
+      const params = new URLSearchParams({ campaign: lookupCampaignId! })
+      const response = await fetch(`/admin/api/market-making/campaigns?${params}`, { cache: 'no-store' })
+      if (response.status === 404) {
+        return { data: [] } satisfies MarketMakingCampaignsResponse
+      }
+      if (!response.ok) {
+        throw new Error(copy.loadError)
+      }
+      return (await response.json()) as MarketMakingCampaignsResponse
+    },
+  })
+  const handledCampaignId = useRef<string | null>(null)
   useEffect(() => {
-    const latestCampaigns = campaignsQuery.data?.data
-    if (!latestCampaigns) {
-      return
-    }
+    const latestCampaigns = [...(campaignsQuery.data?.data ?? []), ...(campaignLookupQuery.data?.data ?? [])]
     const latestById = new Map(latestCampaigns.map((campaign) => [campaign.id, campaign]))
     setSelected((current) => (current ? (latestById.get(current.id) ?? null) : current))
     setCancelCampaign((current) => (current ? (latestById.get(current.id) ?? null) : current))
     setDisputeCampaign((current) => (current ? (latestById.get(current.id) ?? null) : current))
-  }, [campaignsQuery.data?.data])
+    if (lookupCampaignId && handledCampaignId.current !== lookupCampaignId) {
+      const linkedCampaign = latestById.get(lookupCampaignId)
+      if (linkedCampaign) {
+        handledCampaignId.current = lookupCampaignId
+        setSearch(lookupCampaignId)
+        setSelected(linkedCampaign)
+      }
+    }
+  }, [campaignLookupQuery.data?.data, campaignsQuery.data?.data, lookupCampaignId])
   const pendingWithdrawalsQuery = useQuery({
     queryKey: ['market-making-pending-withdrawals', address?.toLowerCase()],
     enabled: Boolean(address && publicClient),
@@ -765,7 +794,11 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
   })
   const campaigns = useMemo(() => {
     const normalizedSearch = search.trim().toLowerCase()
-    return (campaignsQuery.data?.data ?? []).filter((campaign) => {
+    const allCampaigns = new Map<string, MarketMakingCampaignRecord>()
+    for (const campaign of [...(campaignsQuery.data?.data ?? []), ...(campaignLookupQuery.data?.data ?? [])]) {
+      allCampaigns.set(campaign.id, campaign)
+    }
+    return [...allCampaigns.values()].filter((campaign) => {
       const effectiveStatus = getEffectiveCampaignStatus(campaign.status, campaign.serviceEnd, now)
       if (!matchesStatus(effectiveStatus, filter)) {
         return false
@@ -774,11 +807,12 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
         return true
       }
       return (
+        campaign.id.toLowerCase().includes(normalizedSearch) ||
         campaign.title.toLowerCase().includes(normalizedSearch) ||
         campaign.markets.some((market) => market.title?.toLowerCase().includes(normalizedSearch))
       )
     })
-  }, [campaignsQuery.data?.data, filter, now, search])
+  }, [campaignLookupQuery.data?.data, campaignsQuery.data?.data, filter, now, search])
   const filters: Array<{ id: EscrowCampaignStatusFilter; label: string }> = [
     { id: 'all', label: copy.all },
     { id: 'open', label: copy.open },
@@ -790,6 +824,11 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
   ]
   const pendingWithdrawalAtomic = pendingWithdrawalsQuery.data ?? '0'
   const hasPendingWithdrawal = BigInt(pendingWithdrawalAtomic) > 0n
+  const lookupFoundInCampaigns = Boolean(
+    lookupCampaignId && campaignsQuery.data?.data.some((campaign) => campaign.id === lookupCampaignId),
+  )
+  const isLoading = campaignsQuery.isLoading || (campaignLookupQuery.isLoading && !lookupFoundInCampaigns)
+  const isError = campaignsQuery.isError || (campaignLookupQuery.isError && !lookupFoundInCampaigns)
   const reasons: Array<{ id: DisputeReason; label: string }> = [
     { id: 'liquidity_unavailable', label: copy.liquidityUnavailable },
     { id: 'spread_exceeded', label: copy.spreadExceeded },
@@ -896,7 +935,21 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
           <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />
           <Input
             value={search}
-            onChange={(event) => setSearch(event.target.value)}
+            onChange={(event) => {
+              const value = event.target.value
+              setSearch(value)
+              if (!/^(0|[1-9][0-9]*)$/.test(value.trim())) {
+                setLookupId(null)
+              }
+            }}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                const value = search.trim()
+                if (/^(0|[1-9][0-9]*)$/.test(value)) {
+                  setLookupId(value)
+                }
+              }
+            }}
             placeholder={copy.search}
             className="pl-9"
           />
@@ -932,21 +985,21 @@ export default function MarketMakingCampaigns({ locale, copy }: Props) {
         </div>
       </div>
 
-      {campaignsQuery.isLoading && (
+      {isLoading && (
         <div className="flex items-center justify-center gap-2 py-20 text-sm text-muted-foreground">
           <LoaderCircleIcon className="size-4 animate-spin" />
           {copy.waiting}
         </div>
       )}
-      {campaignsQuery.isError && <div className="py-20 text-center text-sm text-destructive">{copy.loadError}</div>}
-      {!campaignsQuery.isLoading && !campaignsQuery.isError && campaigns.length === 0 && (
+      {isError && <div className="py-20 text-center text-sm text-destructive">{copy.loadError}</div>}
+      {!isLoading && !isError && campaigns.length === 0 && (
         <div className="py-20 text-center">
           <CircleDollarSignIcon className="mx-auto size-7 text-muted-foreground" />
           <h2 className="mt-4 font-semibold">{copy.noCampaigns}</h2>
           <p className="mt-1 text-sm text-muted-foreground">{copy.noCampaignsDescription}</p>
         </div>
       )}
-      {campaigns.length > 0 && (
+      {!isLoading && !isError && campaigns.length > 0 && (
         <Table>
           <TableHeader>
             <TableRow>

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -2122,10 +2122,21 @@ export default function MarketMakingDiscovery({
   campaignsCopy,
   howItWorksCopy,
 }: MarketMakingDiscoveryProps) {
+  const [linkedCampaignId, setLinkedCampaignId] = useState<string | null>(null)
   const [query, setQuery] = useState('')
   const [source, setSource] = useState<MarketMakingSourceFilter>('all')
+  const [activeTab, setActiveTab] = useState<'sponsor' | 'campaigns'>('sponsor')
   const [selectedMarket, setSelectedMarket] = useState<MarketMakingDiscoveryItem | null>(null)
   const [howItWorksOpen, setHowItWorksOpen] = useState(false)
+  useEffect(() => {
+    const value = new URLSearchParams(window.location.search).get('campaign')
+    setLinkedCampaignId(value && /^(0|[1-9][0-9]*)$/.test(value) ? value : null)
+  }, [])
+  useEffect(() => {
+    if (linkedCampaignId && /^(0|[1-9][0-9]*)$/.test(linkedCampaignId)) {
+      setActiveTab('campaigns')
+    }
+  }, [linkedCampaignId])
   const deferredQuery = useDeferredValue(query.trim())
   const filters = useMemo(
     () => [
@@ -2138,6 +2149,7 @@ export default function MarketMakingDiscovery({
   )
   const { data, isLoading, isFetching, isError } = useQuery({
     queryKey: ['admin-market-making', source, deferredQuery],
+    enabled: activeTab === 'sponsor',
     staleTime: 60_000,
     queryFn: async () => {
       const params = new URLSearchParams({ source, limit: '18' })
@@ -2154,7 +2166,7 @@ export default function MarketMakingDiscovery({
 
   return (
     <section className="min-h-[calc(100dvh-6rem)] min-w-0">
-      <Tabs defaultValue="sponsor">
+      <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as 'sponsor' | 'campaigns')}>
         <div className="flex items-center justify-between gap-3">
           <TabsList className="h-10">
             <TabsTrigger value="sponsor" className="h-8 px-5">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Open campaigns by ID from search and deep links to enable direct navigation and automatic selection in the Admin UI.

- API: `GET /admin/api/market-making/campaigns` now accepts `?campaign=<id>` (numeric only). Returns only that campaign if sponsored by the current user; 400 for non-numeric IDs, 404 if not found/not owned, and 502 if the index is unavailable.
- Admin UI (Campaigns): reads `?campaign=<id>`, looks up that campaign, de-duplicates with the list, selects it, and seeds the search with the ID. Pressing Enter on a numeric search triggers an ID lookup; non-numeric input clears the lookup. Search now matches by campaign ID. Loading and error states are unified across list and lookup queries.
- Admin UI (Discovery): if `?campaign=<id>` is present, switches to the Campaigns tab and disables Sponsor tab fetching.

<sup>Written for commit 0e2d16391857c42b762c96210e01fd165da65a49. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

