### PR TITLE
fix: route unstructured sports subcategories to predictions

### DIFF
--- a/docs/api-reference/market-data/get-neg-risk-by-path.mdx
+++ b/docs/api-reference/market-data/get-neg-risk-by-path.mdx
@@ -1,9 +1,9 @@
 ---
 title: Get Neg Risk By Token
-description: 'Get the negative-risk flag for a token path parameter'
+description: 'Get the negative-risk flag for a token query parameter'
 full: true
 _openapi:
   method: GET
 ---
 
-<APIPage document="clob" operations={[{ path: '/neg-risk/{token_id}', method: 'get' }]} />
+<APIPage document="clob" operations={[{ path: '/neg-risk', method: 'get' }]} />

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
@@ -13,6 +13,7 @@ import EventShare from '@/app/[locale]/(platform)/event/[slug]/_components/Event
 import EventIconImage from '@/components/EventIconImage'
 import { Link } from '@/i18n/navigation'
 import { resolveCryptoCadenceEventPresentation } from '@/lib/crypto-cadence-event'
+import { resolveEventHeaderSubcategoryHref } from '@/lib/event-header-routing'
 import { isPlatformMainCategorySlug } from '@/lib/platform-routing'
 import { cn } from '@/lib/utils'
 
@@ -79,7 +80,11 @@ function resolveEventHeaderTaxonomy({
     },
     subcategory: matchedSubcategory
       ? {
-          href: `/${resolvedMainSlug}/${normalizeTagSlug(matchedSubcategory.slug)}`,
+          href: resolveEventHeaderSubcategoryHref({
+            event,
+            mainSlug: resolvedMainSlug,
+            subcategorySlug: matchedSubcategory.slug,
+          }),
           label: matchedSubcategory.name.trim(),
         }
       : fallbackSubcategory

--- a/src/lib/event-header-routing.ts
+++ b/src/lib/event-header-routing.ts
@@ -1,0 +1,41 @@
+import type { Event } from '@/types'
+
+const DEDICATED_SPORTS_ROOT_SLUGS = new Set(['sports', 'esports'])
+
+function normalizeHeaderRouteSlug(value: string) {
+  return value.trim().toLowerCase()
+}
+
+function hasStructuredSportsMetadata(
+  event: Pick<Event, 'sports_event_id' | 'sports_event_slug' | 'sports_sport_slug' | 'sports_teams'>,
+) {
+  return Boolean(
+    event.sports_event_id ||
+    event.sports_event_slug?.trim() ||
+    event.sports_sport_slug?.trim() ||
+    event.sports_teams?.length,
+  )
+}
+
+export function resolveEventHeaderSubcategoryHref({
+  event,
+  mainSlug,
+  subcategorySlug,
+}: {
+  event: Pick<Event, 'sports_event_id' | 'sports_event_slug' | 'sports_sport_slug' | 'sports_teams'>
+  mainSlug: string
+  subcategorySlug: string
+}) {
+  const normalizedMainSlug = normalizeHeaderRouteSlug(mainSlug)
+  const normalizedSubcategorySlug = normalizeHeaderRouteSlug(subcategorySlug)
+
+  if (!normalizedMainSlug || !normalizedSubcategorySlug) {
+    return null
+  }
+
+  if (DEDICATED_SPORTS_ROOT_SLUGS.has(normalizedMainSlug) && !hasStructuredSportsMetadata(event)) {
+    return `/predictions/${normalizedSubcategorySlug}`
+  }
+
+  return `/${normalizedMainSlug}/${normalizedSubcategorySlug}`
+}

--- a/src/lib/event-header-routing.ts
+++ b/src/lib/event-header-routing.ts
@@ -1,6 +1,6 @@
 import type { Event } from '@/types'
 
-const DEDICATED_SPORTS_ROOT_SLUGS = new Set(['sports', 'esports'])
+import { PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS } from '@/lib/platform-routing'
 
 function normalizeHeaderRouteSlug(value: string) {
   return value.trim().toLowerCase()
@@ -33,7 +33,7 @@ export function resolveEventHeaderSubcategoryHref({
     return null
   }
 
-  if (DEDICATED_SPORTS_ROOT_SLUGS.has(normalizedMainSlug) && !hasStructuredSportsMetadata(event)) {
+  if (PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS.has(normalizedMainSlug) && !hasStructuredSportsMetadata(event)) {
     return `/predictions/${normalizedSubcategorySlug}`
   }
 

--- a/src/lib/platform-navigation.ts
+++ b/src/lib/platform-navigation.ts
@@ -1,3 +1,5 @@
+import { PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS } from '@/lib/platform-routing'
+
 export interface PlatformNavigationChild {
   name: string
   slug: string
@@ -144,8 +146,6 @@ export function parsePlatformPathname(
   const isHomePage = pathname === '/'
   const isMentionsPage = pathname === '/mentions'
   const isEventPathPage = pathname.startsWith('/event/')
-  const sportsLikeRootSlugs = new Set(['sports', 'esports'])
-
   if (pathSegments.length === 0) {
     return {
       isEventPathPage,
@@ -160,7 +160,7 @@ export function parsePlatformPathname(
   }
 
   const [candidate, subcategoryCandidate] = pathSegments
-  if (sportsLikeRootSlugs.has(candidate)) {
+  if (PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS.has(candidate)) {
     return {
       isEventPathPage,
       isHomeLikePage: true,

--- a/src/lib/platform-routing.ts
+++ b/src/lib/platform-routing.ts
@@ -19,7 +19,7 @@ const PLATFORM_RESERVED_ROOT_SLUGS = new Set([
 
 const PLATFORM_NON_CATEGORY_MAIN_TAG_SLUGS = new Set(['trending'])
 
-const PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS = new Set(['sports', 'esports'])
+export const PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS: ReadonlySet<string> = new Set(['sports', 'esports'])
 
 interface PlatformMainTagLike {
   slug: string

--- a/src/lib/prediction-search.ts
+++ b/src/lib/prediction-search.ts
@@ -190,7 +190,8 @@ export function resolvePredictionSearchContext(tags: PlatformNavigationTag[], sl
   }
 
   for (const tag of tags) {
-    if (!isDynamicHomeCategorySlug(tag.slug)) {
+    const isDedicatedSportsCategory = tag.slug === 'sports' || tag.slug === 'esports'
+    if (!isDynamicHomeCategorySlug(tag.slug) && !isDedicatedSportsCategory) {
       continue
     }
 

--- a/src/lib/prediction-search.ts
+++ b/src/lib/prediction-search.ts
@@ -201,10 +201,10 @@ export function resolvePredictionSearchContext(tags: PlatformNavigationTag[], sl
         inputValue,
         kind: 'main-tag',
         label: tag.name,
-        mainTag: normalizedTagSlug,
+        mainTag: tag.slug,
         query: '',
         slug: normalizedSlug,
-        tag: normalizedTagSlug,
+        tag: tag.slug,
       }
     }
 
@@ -214,10 +214,10 @@ export function resolvePredictionSearchContext(tags: PlatformNavigationTag[], sl
         inputValue,
         kind: 'child-tag',
         label: matchingChild.name,
-        mainTag: normalizedTagSlug,
+        mainTag: tag.slug,
         query: '',
         slug: normalizedSlug,
-        tag: slugifyPredictionSearchValue(matchingChild.slug),
+        tag: matchingChild.slug,
       }
     }
   }

--- a/src/lib/prediction-search.ts
+++ b/src/lib/prediction-search.ts
@@ -1,6 +1,6 @@
 import type { PlatformNavigationTag } from '@/lib/platform-navigation'
 
-import { isDynamicHomeCategorySlug } from '@/lib/platform-routing'
+import { isDynamicHomeCategorySlug, PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS } from '@/lib/platform-routing'
 
 export interface SearchCategoryMatch {
   href: string
@@ -190,8 +190,9 @@ export function resolvePredictionSearchContext(tags: PlatformNavigationTag[], sl
   }
 
   for (const tag of tags) {
-    const isDedicatedSportsCategory = tag.slug === 'sports' || tag.slug === 'esports'
-    if (!isDynamicHomeCategorySlug(tag.slug) && !isDedicatedSportsCategory) {
+    const normalizedTagSlug = tag.slug.trim().toLowerCase()
+    const isDedicatedSportsCategory = PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS.has(normalizedTagSlug)
+    if (!isDynamicHomeCategorySlug(normalizedTagSlug) && !isDedicatedSportsCategory) {
       continue
     }
 
@@ -200,10 +201,10 @@ export function resolvePredictionSearchContext(tags: PlatformNavigationTag[], sl
         inputValue,
         kind: 'main-tag',
         label: tag.name,
-        mainTag: tag.slug,
+        mainTag: normalizedTagSlug,
         query: '',
         slug: normalizedSlug,
-        tag: tag.slug,
+        tag: normalizedTagSlug,
       }
     }
 
@@ -213,10 +214,10 @@ export function resolvePredictionSearchContext(tags: PlatformNavigationTag[], sl
         inputValue,
         kind: 'child-tag',
         label: matchingChild.name,
-        mainTag: tag.slug,
+        mainTag: normalizedTagSlug,
         query: '',
         slug: normalizedSlug,
-        tag: matchingChild.slug,
+        tag: slugifyPredictionSearchValue(matchingChild.slug),
       }
     }
   }

--- a/tests/unit/eventHeaderRouting.test.ts
+++ b/tests/unit/eventHeaderRouting.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveEventHeaderSubcategoryHref } from '@/lib/event-header-routing'
+
+describe('event header routing', () => {
+  it('routes unstructured Sports children to prediction results', () => {
+    expect(
+      resolveEventHeaderSubcategoryHref({
+        event: {},
+        mainSlug: 'sports',
+        subcategorySlug: 'HCL',
+      }),
+    ).toBe('/predictions/hcl')
+  })
+
+  it('keeps structured Sports children on sports routes', () => {
+    expect(
+      resolveEventHeaderSubcategoryHref({
+        event: {
+          sports_event_slug: 'lakers-celtics-2026-03-09',
+          sports_sport_slug: 'nba',
+        },
+        mainSlug: 'sports',
+        subcategorySlug: 'NBA',
+      }),
+    ).toBe('/sports/nba')
+  })
+
+  it('keeps non-dedicated category children on their category routes', () => {
+    expect(
+      resolveEventHeaderSubcategoryHref({
+        event: {},
+        mainSlug: 'politics',
+        subcategorySlug: 'Brazil',
+      }),
+    ).toBe('/politics/brazil')
+  })
+})

--- a/tests/unit/openapiDocs.test.ts
+++ b/tests/unit/openapiDocs.test.ts
@@ -1,0 +1,27 @@
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+interface OpenApiDocument {
+  paths?: Record<string, Record<string, unknown>>
+}
+
+async function readOpenApiDocument() {
+  const schemaPath = path.join(process.cwd(), 'docs/api-reference/schemas/openapi-clob.json')
+  return JSON.parse(await readFile(schemaPath, 'utf8')) as OpenApiDocument
+}
+
+async function readDocumentationPage() {
+  const pagePath = path.join(process.cwd(), 'docs/api-reference/market-data/get-neg-risk-by-path.mdx')
+  return await readFile(pagePath, 'utf8')
+}
+
+describe('OpenAPI documentation references', () => {
+  it('references the schema path for the neg-risk token endpoint', async () => {
+    const [document, page] = await Promise.all([readOpenApiDocument(), readDocumentationPage()])
+
+    expect(document.paths?.['/neg-risk']?.get).toBeDefined()
+    expect(page).toContain("path: '/neg-risk'")
+    expect(page).not.toContain("path: '/neg-risk/{token_id}'")
+  })
+})

--- a/tests/unit/predictionSearch.test.ts
+++ b/tests/unit/predictionSearch.test.ts
@@ -60,9 +60,18 @@ describe('prediction search helpers', () => {
     expect(resolvePredictionSearchContext(sportsNavigationTags as any, 'hcl')).toMatchObject({
       kind: 'child-tag',
       label: 'HCL',
-      mainTag: 'sports',
+      mainTag: ' Sports ',
       query: '',
-      tag: 'hcl',
+      tag: ' HCL ',
+    })
+  })
+
+  it('preserves stored parent slugs while matching normalized routes', () => {
+    expect(resolvePredictionSearchContext(sportsNavigationTags as any, 'sports')).toMatchObject({
+      kind: 'main-tag',
+      mainTag: ' Sports ',
+      query: '',
+      tag: ' Sports ',
     })
   })
 

--- a/tests/unit/predictionSearch.test.ts
+++ b/tests/unit/predictionSearch.test.ts
@@ -23,6 +23,14 @@ const navigationTags = [
   },
 ] as const
 
+const sportsNavigationTags = [
+  {
+    slug: 'sports',
+    name: 'Sports',
+    childs: [{ slug: 'hcl', name: 'HCL' }],
+  },
+] as const
+
 describe('prediction search helpers', () => {
   it('builds a predictions route path from free-text input', () => {
     expect(buildPredictionResultsPath('Future Bets')).toBe('/predictions/future-bets')
@@ -45,6 +53,16 @@ describe('prediction search helpers', () => {
       mainTag: 'politics',
       query: '',
       tag: 'brazil',
+    })
+  })
+
+  it('resolves children of dedicated sports categories to prediction tag contexts', () => {
+    expect(resolvePredictionSearchContext(sportsNavigationTags as any, 'hcl')).toMatchObject({
+      kind: 'child-tag',
+      label: 'HCL',
+      mainTag: 'sports',
+      query: '',
+      tag: 'hcl',
     })
   })
 

--- a/tests/unit/predictionSearch.test.ts
+++ b/tests/unit/predictionSearch.test.ts
@@ -25,9 +25,9 @@ const navigationTags = [
 
 const sportsNavigationTags = [
   {
-    slug: 'sports',
+    slug: ' Sports ',
     name: 'Sports',
-    childs: [{ slug: 'hcl', name: 'HCL' }],
+    childs: [{ slug: ' HCL ', name: 'HCL' }],
   },
 ] as const
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Routes sports subcategory links for events without structured sports metadata to prediction results and updates the neg-risk docs to match GET `/neg-risk`. Previously all sports subcategories linked to `/sports/:slug`; now unstructured sports link to `/predictions/:slug` while structured sports and non-sports keep category routes. Also preserves stored prediction tag slugs while matching normalized routes.

- Adds `resolveEventHeaderSubcategoryHref` in EventHeader to choose `/predictions/:slug` vs `/:main/:subcategory` based on sports metadata.
- Centralizes sports/esports root detection with `PLATFORM_RESERVED_MAIN_CATEGORY_SLUGS`; updates platform navigation and prediction search so children of dedicated sports categories resolve to prediction tag contexts and preserve stored slugs.
- Updates the docs to use a token query parameter at `/neg-risk`; adds unit tests for OpenAPI references, header routing, and prediction search.

<sup>Written for commit f76aa687d48e8f637da327c7d2105163770bfb33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

