### PR TITLE
feat: support recurring series imports

### DIFF
--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -216,6 +216,7 @@ interface EscrowPreviewResponse {
 
 interface EscrowConfigResponse {
   pricingConfig: {
+    acceptDeadlineLeadSeconds?: number
     baseCoverageBps?: number
     defaultServiceStartDelaySeconds?: number
     minimumServiceDurationSeconds?: number
@@ -424,10 +425,11 @@ function getMarketEndDate(item: MarketMakingDiscoveryItem) {
   return fallback
 }
 
-function getMinimumServiceEndDate(config: EscrowConfigResponse | undefined) {
+function getMinimumServiceEndDate(config: EscrowConfigResponse | undefined, recurringAnchor: boolean) {
   const pricing = config?.pricingConfig
-  const minimumSeconds =
-    (pricing?.defaultServiceStartDelaySeconds ?? 86_400) + (pricing?.minimumServiceDurationSeconds ?? 86_400)
+  const minimumSeconds = recurringAnchor
+    ? (pricing?.acceptDeadlineLeadSeconds ?? 3_600) * 3
+    : (pricing?.defaultServiceStartDelaySeconds ?? 86_400) + (pricing?.minimumServiceDurationSeconds ?? 86_400)
   return new Date(Date.now() + minimumSeconds * 1_000)
 }
 
@@ -1060,18 +1062,28 @@ function CampaignDialog({
   }
   const marketEndDate = getMarketEndDate(item)
   const initialServiceEnd = marketEndDate
+  const [sponsorSeries, setSponsorSeries] = useState(false)
+  const polymarketConditionIds = useMemo(
+    () => item.markets.flatMap((market) => (market.polymarketConditionId ? [market.polymarketConditionId] : [])),
+    [item.markets],
+  )
+  const seriesUsesPolymarketDeployments =
+    sponsorSeries &&
+    item.hedgeAvailable &&
+    item.creatorFilter?.toLowerCase() === POLY_SYNCER_CREATOR_ADDRESS.toLowerCase() &&
+    polymarketConditionIds.length === item.markets.length
+  const usesImportFlow = item.needsDeployment || seriesUsesPolymarketDeployments
   const quoteConditionIds = useMemo(
     () =>
       item.markets.flatMap((market) => {
-        const conditionId = item.needsDeployment ? market.polymarketConditionId : market.kuestConditionId
+        const conditionId = usesImportFlow ? market.polymarketConditionId : market.kuestConditionId
         return conditionId ? [conditionId] : []
       }),
-    [item.markets, item.needsDeployment],
+    [item.markets, usesImportFlow],
   )
   const [depth, setDepth] = useState(1000)
   const [spread, setSpread] = useState(300)
   const [serviceEnd, setServiceEnd] = useState(initialServiceEnd)
-  const [sponsorSeries, setSponsorSeries] = useState(false)
   const [calendarOpen, setCalendarOpen] = useState(false)
   const [issuedQuote, setIssuedQuote] = useState<EscrowIssuedQuoteResponse | null>(null)
   const [issueError, setIssueError] = useState<string | null>(null)
@@ -1089,7 +1101,9 @@ function CampaignDialog({
   const emailLinkRequestId = useRef(0)
   const activeEmailWallet = useRef(address)
   const importStorageKey =
-    address && item.slug ? `kuest-market-import:${chainId}:${address.toLowerCase()}:${item.slug}` : null
+    address && item.slug
+      ? `kuest-market-import:${chainId}:${address.toLowerCase()}:${item.slug}:${sponsorSeries ? 'series' : 'event'}`
+      : null
   const importPaymentStorageKey = importStorageKey ? `${importStorageKey}:payment` : null
   const [pendingImportPaymentHash, setPendingImportPaymentHash] = useState<string | null>(null)
 
@@ -1108,7 +1122,7 @@ function CampaignDialog({
       buildMarketMakerQuoteInput({
         sponsor: address ?? '',
         importId,
-        marketSource: item.needsDeployment ? 'polymarket' : 'kuest',
+        marketSource: usesImportFlow ? 'polymarket' : 'kuest',
         conditionIds: quoteConditionIds,
         depthPerSideAtomic: (BigInt(depth) * USDC_ATOMIC_SCALE).toString(),
         maxSpreadBps: spread,
@@ -1122,12 +1136,12 @@ function CampaignDialog({
       depth,
       item.creatorFilter,
       importId,
-      item.needsDeployment,
       item.seriesSlug,
       quoteConditionIds,
       serviceEnd,
       sponsorSeries,
       spread,
+      usesImportFlow,
     ],
   )
   const configQuery = useQuery({
@@ -1137,7 +1151,7 @@ function CampaignDialog({
     retry: false,
     queryFn: () => fetchEscrowJson<EscrowConfigResponse>(`${escrowBaseUrl}/api/config`),
   })
-  const minimumServiceEndDate = getMinimumServiceEndDate(configQuery.data)
+  const minimumServiceEndDate = getMinimumServiceEndDate(configQuery.data, Boolean(item.seriesSlug))
   const hasSelectableServiceWindow = sponsorSeries
     ? Boolean(item.seriesSlug && item.creatorFilter)
     : marketEndDate >= minimumServiceEndDate
@@ -1152,7 +1166,6 @@ function CampaignDialog({
     enabled: canRequestQuote,
     staleTime: 15_000,
     retry: false,
-    placeholderData: (previousData) => previousData,
     queryFn: () =>
       fetchEscrowJson<EscrowPreviewResponse>(`${escrowBaseUrl}/api/quote/preview`, {
         method: 'POST',
@@ -1167,17 +1180,22 @@ function CampaignDialog({
     configQuery.data?.pricingConfig.terms?.minimumTwoSidedCoverageBps ??
     configQuery.data?.pricingConfig.baseCoverageBps ??
     null
+  const fallbackServiceStart =
+    Math.floor(Date.now() / 1_000) +
+    (item.seriesSlug
+      ? (configQuery.data?.pricingConfig.acceptDeadlineLeadSeconds ?? 3_600) * 2
+      : (configQuery.data?.pricingConfig.defaultServiceStartDelaySeconds ?? 86_400))
   const serviceDurationDays = preview
     ? Math.max(1, Math.ceil((preview.serviceEnd - preview.serviceStart) / (24 * 60 * 60)))
-    : null
+    : Math.max(1, Math.ceil((Math.floor(serviceEnd.getTime() / 1_000) - fallbackServiceStart) / (24 * 60 * 60)))
   const marketCountLabel =
     item.markets.length > 1 ? formatCountTemplate(copy.marketCount, item.markets.length, locale) : null
   const importReady = importValue !== null && ['ready', 'activated'].includes(importValue.state)
   const costs = preview?.costs ?? null
   const initialDeploymentFeeAtomic = importValue?.costs.initialDeploymentFeeAtomic ?? costs?.initialDeploymentFeeAtomic
-  const deploymentFeePending = item.needsDeployment && !(importValue?.costs.initialDeploymentFeePaid ?? false)
+  const deploymentFeePending = usesImportFlow && !(importValue?.costs.initialDeploymentFeePaid ?? false)
   const importPaymentRequired =
-    item.needsDeployment &&
+    usesImportFlow &&
     !pendingImportPaymentHash &&
     (!importValue || importValue.state === 'awaiting_payment' || importValue.state === 'expired')
   const requiredBalanceAtomic = costs
@@ -1210,7 +1228,7 @@ function CampaignDialog({
     sponsorBalanceQuery.data < requiredBalanceAtomic
 
   useEffect(() => {
-    if (!open || !item.needsDeployment || !importStorageKey) {
+    if (!open || !usesImportFlow || !importStorageKey) {
       return
     }
     const stored = window.localStorage.getItem(importStorageKey)
@@ -1221,7 +1239,7 @@ function CampaignDialog({
     if (storedPayment?.startsWith('0x')) {
       setPendingImportPaymentHash(storedPayment)
     }
-  }, [importPaymentStorageKey, importStorageKey, item.needsDeployment, open])
+  }, [importPaymentStorageKey, importStorageKey, open, usesImportFlow])
 
   const importQuery = useQuery({
     queryKey: ['market-making-import', escrowBaseUrl, importId],
@@ -1376,7 +1394,7 @@ function CampaignDialog({
     try {
       let activeImport = importValue
       let createdImportNow = false
-      if (item.needsDeployment) {
+      if (usesImportFlow) {
         if (!item.slug) {
           throw new Error(copy.marketDataUnavailable)
         }
@@ -1403,7 +1421,12 @@ function CampaignDialog({
           activeImport = await fetchEscrowJson<EscrowImportResponse>(`${escrowBaseUrl}/api/imports`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ sponsor: address, eventSlug: item.slug, conditionIds: quoteConditionIds }),
+            body: JSON.stringify({
+              sponsor: address,
+              eventSlug: item.slug,
+              conditionIds: quoteConditionIds,
+              ...('series' in quoteInput ? { series: quoteInput.series } : {}),
+            }),
           })
           setImportId(activeImport.importId)
           setImportValue(activeImport)
@@ -1470,7 +1493,7 @@ function CampaignDialog({
         }
       }
 
-      if (item.needsDeployment && !activeImport) {
+      if (usesImportFlow && !activeImport) {
         throw new Error(copy.quoteUnavailable)
       }
 
@@ -1478,14 +1501,14 @@ function CampaignDialog({
         issuedQuote && issuedQuote.quote.validUntil > Math.floor(Date.now() / 1000) + 15
           ? issuedQuote
           : await fetchEscrowJson<EscrowIssuedQuoteResponse>(
-              item.needsDeployment
+              usesImportFlow
                 ? `${escrowBaseUrl}/api/imports/${activeImport?.importId}/quote`
                 : `${escrowBaseUrl}/api/quote`,
               {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(
-                  item.needsDeployment
+                  usesImportFlow
                     ? {
                         sponsor: address,
                         depthPerSideAtomic: quoteInput.depthPerSideAtomic,
@@ -1780,6 +1803,12 @@ function CampaignDialog({
               checked={sponsorSeries}
               onCheckedChange={(checked) => {
                 setSponsorSeries(checked)
+                if (!checked) {
+                  setServiceEnd(marketEndDate)
+                }
+                setImportId(null)
+                setImportValue(null)
+                setPendingImportPaymentHash(null)
                 clearIssuedQuote()
               }}
             />
@@ -1818,7 +1847,7 @@ function CampaignDialog({
                   <span className="text-muted-foreground">{copy.kuestFee}</span>
                   <span className="font-medium">{formatUsdcString(breakdown.protocolFee, locale)}</span>
                 </div>
-                {item.needsDeployment && (
+                {usesImportFlow && (
                   <div className="flex items-center justify-between gap-4">
                     <span className="text-muted-foreground">{copy.importEvent}</span>
                     <span className="font-medium">{formatUsdcAtomic(initialDeploymentFeeAtomic, locale)}</span>

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -68,6 +68,7 @@ import {
 import { MARKET_MAKER_ESCROW_ABI } from '@/lib/market-maker-escrow'
 import {
   buildMarketMakerQuoteInput,
+  marketImportStorageKey,
   requiredSponsorBalanceAtomic,
   sponsorshipDurationSubtitle,
 } from '@/lib/market-making-series'
@@ -1102,7 +1103,12 @@ function CampaignDialog({
   const activeEmailWallet = useRef(address)
   const importStorageKey =
     address && item.slug
-      ? `kuest-market-import:${chainId}:${address.toLowerCase()}:${item.slug}:${sponsorSeries ? 'series' : 'event'}`
+      ? marketImportStorageKey({
+          chainId,
+          wallet: address,
+          eventSlug: item.slug,
+          sponsorSeries,
+        })
       : null
   const importPaymentStorageKey = importStorageKey ? `${importStorageKey}:payment` : null
   const [pendingImportPaymentHash, setPendingImportPaymentHash] = useState<string | null>(null)

--- a/src/lib/market-making-series.ts
+++ b/src/lib/market-making-series.ts
@@ -11,6 +11,16 @@ export interface SeriesQuoteInputParams {
   creatorFilter?: string | null
 }
 
+export function marketImportStorageKey(params: {
+  chainId: number
+  wallet: string
+  eventSlug: string
+  sponsorSeries: boolean
+}) {
+  const legacyEventKey = `kuest-market-import:${params.chainId}:${params.wallet.toLowerCase()}:${params.eventSlug}`
+  return params.sponsorSeries ? `${legacyEventKey}:series` : legacyEventKey
+}
+
 export function buildMarketMakerQuoteInput(params: SeriesQuoteInputParams): Record<string, unknown> {
   const input: Record<string, unknown> = {
     sponsor: params.sponsor,

--- a/tests/unit/marketMakingSeries.test.ts
+++ b/tests/unit/marketMakingSeries.test.ts
@@ -12,12 +12,28 @@ import {
 import {
   buildMarketMakerQuoteInput,
   displayedCostAtomic,
+  marketImportStorageKey,
   requiredSponsorBalanceAtomic,
   seriesMarketDataSummary,
   sponsorshipDurationSubtitle,
 } from '@/lib/market-making-series'
 
 describe('series market-making helpers', () => {
+  it('preserves legacy event import keys and isolates series imports', () => {
+    const params = {
+      chainId: 80002,
+      wallet: '0x00000000000000000000000000000000000000AB',
+      eventSlug: 'bitcoin-up-or-down',
+    }
+
+    expect(marketImportStorageKey({ ...params, sponsorSeries: false })).toBe(
+      'kuest-market-import:80002:0x00000000000000000000000000000000000000ab:bitcoin-up-or-down',
+    )
+    expect(marketImportStorageKey({ ...params, sponsorSeries: true })).toBe(
+      'kuest-market-import:80002:0x00000000000000000000000000000000000000ab:bitcoin-up-or-down:series',
+    )
+  })
+
   it('keeps the selected event end when series sponsorship is disabled', () => {
     expect(
       buildMarketMakerQuoteInput({

--- a/tests/unit/marketMakingSeries.test.ts
+++ b/tests/unit/marketMakingSeries.test.ts
@@ -18,6 +18,26 @@ import {
 } from '@/lib/market-making-series'
 
 describe('series market-making helpers', () => {
+  it('keeps the selected event end when series sponsorship is disabled', () => {
+    expect(
+      buildMarketMakerQuoteInput({
+        sponsor: '0x0000000000000000000000000000000000000002',
+        importId: null,
+        marketSource: 'polymarket',
+        conditionIds: ['0x' + '11'.repeat(32)],
+        depthPerSideAtomic: '1000000000',
+        maxSpreadBps: 300,
+        serviceEnd: 2_000_000_000,
+        sponsorSeries: false,
+        seriesSlug: 'btc-up-or-down-daily',
+        creatorFilter: '0x0000000000000000000000000000000000000004',
+      }),
+    ).toMatchObject({
+      marketSource: 'polymarket',
+      serviceEnd: 2_000_000_000,
+    })
+  })
+
   it('builds the canonical series quote payload', () => {
     expect(
       buildMarketMakerQuoteInput({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds recurring series sponsorship to the market-making import flow so Polymarket-backed series can be imported and quoted end-to-end. Previously imports ran only when `item.needsDeployment`; now the import flow also triggers for a valid sponsored series, changing quote routing, payment prompts, and default service windows.

- Review notes
  - Import routing: Introduces `usesImportFlow` to drive condition IDs, `marketSource`, and quote endpoints; includes an optional `series` in POST /api/imports.
  - Config: Adds optional `acceptDeadlineLeadSeconds`; `getMinimumServiceEndDate` now takes a recurring anchor and uses this to compute minimum service end and a series-specific fallback service start.
  - State/persistence: Adds `marketImportStorageKey` that preserves legacy event import keys and isolates series imports via a `:series` suffix; toggling “Sponsor series” clears import state and resets `serviceEnd` to the event end.
  - UI/payment: Shows deployment fees and import payment prompts only when the import flow is active; falls back to a computed service duration when preview is unavailable.
  - Tests: Covers storage key isolation and preserving the selected event end when series sponsorship is disabled.

- Rollout
  - Ensure POST /api/imports accepts an optional `series` field; backend config may expose `acceptDeadlineLeadSeconds`.
  - No storage migration needed; legacy LocalStorage keys are preserved.

<sup>Written for commit 8de69447cbf081dea710f7bf509e9b66dcbc36f9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

