### PR TITLE
fix: prevent duplicate import fee payment

### DIFF
--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -68,6 +68,7 @@ import {
 import { MARKET_MAKER_ESCROW_ABI } from '@/lib/market-maker-escrow'
 import {
   buildMarketMakerQuoteInput,
+  displayedCostAtomic,
   marketImportStorageKey,
   requiredSponsorBalanceAtomic,
   sponsorshipDurationSubtitle,
@@ -1199,7 +1200,9 @@ function CampaignDialog({
   const importReady = importValue !== null && ['ready', 'activated'].includes(importValue.state)
   const costs = preview?.costs ?? null
   const initialDeploymentFeeAtomic = importValue?.costs.initialDeploymentFeeAtomic ?? costs?.initialDeploymentFeeAtomic
-  const deploymentFeePending = usesImportFlow && !(importValue?.costs.initialDeploymentFeePaid ?? false)
+  const initialDeploymentFeePaid =
+    importValue?.costs.initialDeploymentFeePaid ?? costs?.initialDeploymentFeePaid ?? false
+  const deploymentFeePending = usesImportFlow && !initialDeploymentFeePaid
   const importPaymentRequired =
     usesImportFlow &&
     !pendingImportPaymentHash &&
@@ -1207,6 +1210,7 @@ function CampaignDialog({
   const requiredBalanceAtomic = costs
     ? requiredSponsorBalanceAtomic(costs, importPaymentRequired && deploymentFeePending)
     : null
+  const displayedTotalAtomic = costs ? displayedCostAtomic({ ...costs, initialDeploymentFeePaid }) : null
   const sponsorBalanceQuery = useQuery({
     queryKey: ['market-making-sponsor-usdc-balance', chainId, address?.toLowerCase()],
     enabled: open && Boolean(address && publicClient),
@@ -1835,7 +1839,7 @@ function CampaignDialog({
               <LoaderCircleIcon className="size-4 animate-spin" />
               {copy.calculating}
             </div>
-          ) : previewQuery.isError || !breakdown || !costs || costs.totalCostAtomic === null ? (
+          ) : previewQuery.isError || !breakdown || !costs || displayedTotalAtomic === null ? (
             <div className="flex min-h-[138px] items-center rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
               {copy.quoteUnavailable}
             </div>
@@ -1853,7 +1857,7 @@ function CampaignDialog({
                   <span className="text-muted-foreground">{copy.kuestFee}</span>
                   <span className="font-medium">{formatUsdcString(breakdown.protocolFee, locale)}</span>
                 </div>
-                {usesImportFlow && (
+                {deploymentFeePending && (
                   <div className="flex items-center justify-between gap-4">
                     <span className="text-muted-foreground">{copy.importEvent}</span>
                     <span className="font-medium">{formatUsdcAtomic(initialDeploymentFeeAtomic, locale)}</span>
@@ -1865,7 +1869,7 @@ function CampaignDialog({
                       ? copy.estimated
                       : copy.total}
                   </span>
-                  <span>{formatUsdcAtomic(costs.totalCostAtomic, locale)}</span>
+                  <span>{formatUsdcAtomic(displayedTotalAtomic, locale)}</span>
                 </div>
               </div>
             </section>

--- a/src/lib/market-making-series.ts
+++ b/src/lib/market-making-series.ts
@@ -55,7 +55,7 @@ export interface EscrowCostBreakdownLike {
 }
 
 export function displayedCostAtomic(costs: EscrowCostBreakdownLike): string | null {
-  return costs.totalCostAtomic
+  return costs.initialDeploymentFeePaid ? costs.campaignFundingTotalAtomic : costs.totalCostAtomic
 }
 
 export function sponsorshipDurationSubtitle(params: {

--- a/tests/unit/marketMakingSeries.test.ts
+++ b/tests/unit/marketMakingSeries.test.ts
@@ -94,6 +94,7 @@ describe('series market-making helpers', () => {
       totalCostStatus: 'final' as const,
     }
     expect(displayedCostAtomic(costs)).toBe('905000000')
+    expect(displayedCostAtomic({ ...costs, initialDeploymentFeePaid: true })).toBe('900000000')
     expect(requiredSponsorBalanceAtomic(costs, true)).toBe(905000000n)
     expect(requiredSponsorBalanceAtomic({ ...costs, initialDeploymentFeePaid: true }, false)).toBe(900000000n)
   })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevent duplicate initial deployment fee collection in the import flow. Previously, the quote, required sponsor balance, and breakdown always included the initial deployment fee even after payment; now, when the fee is paid, we exclude it from totals and hide the line item.

- Derive `initialDeploymentFeePaid` from `importValue` or preview `costs`, and compute `deploymentFeePending` from it.
- Show the "Import event" line only when `deploymentFeePending` is true.
- Use `displayedCostAtomic` to switch totals: use `campaignFundingTotalAtomic` when the initial deployment fee is paid; otherwise use `totalCostAtomic`.
- Update required sponsor balance to exclude the initial deployment fee once paid.
- Add a unit test asserting `displayedCostAtomic` behavior when the initial deployment fee is paid.

<sup>Written for commit b2f29807444719a2528802962ba826c33a5ccb8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

