### PR TITLE
fix: refine featured markets live updates

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -18,6 +18,7 @@ import type {
   HomeFeaturedEventCard,
   HomeFeaturedHotTopic,
   HomeFeaturedOutcomeSummary,
+  HomeFeaturedRolloverEvent,
   HomeFeaturedSideCardSettings,
   Market,
 } from '@/types'
@@ -49,7 +50,7 @@ import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
 import { resolveCryptoCadenceEventPresentation } from '@/lib/crypto-cadence-event'
 import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-routing'
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
-import { resolveHomeFeaturedEventEndTimestamp } from '@/lib/home-featured-rollover'
+import { isHomeFeaturedEventEnded, resolveHomeFeaturedEventEndTimestamp } from '@/lib/home-featured-rollover'
 import { resolveHomeFeaturedSportsScoreboardContent } from '@/lib/home-featured-sports-score'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
 import {
@@ -69,6 +70,7 @@ interface HomeFeaturedEventsCarouselProps {
 const HOME_FEATURED_CHART_HEIGHT = 292
 const HOME_FEATURED_CHART_HEIGHT_OFFSET = 20
 const HOME_FEATURED_LIVE_CHART_WIDTH_OFFSET = 24
+const HOME_FEATURED_ROLLOVER_RETRY_MS = 5_000
 const FEATURED_SPORTS_BUTTON_DARK_TEXT_VAR = '--featured-sports-button-dark-text'
 
 type FeaturedSportsButtonTone = 'home' | 'away' | 'draw' | 'neutral'
@@ -169,6 +171,17 @@ function isNegativeOutcomeLabel(label: string) {
   return /\b(?:no|down|below|lower|under)\b/.test(normalized)
 }
 
+function shouldUseLiveFeaturedOutcomeColors(item: HomeFeaturedEventCard) {
+  if (!item.liveChartConfig || !shouldUseLiveSeriesChart(item.event, item.liveChartConfig)) {
+    return false
+  }
+
+  const [upOutcome, downOutcome] = item.topOutcomes
+  return Boolean(
+    upOutcome && downOutcome && !isNegativeOutcomeLabel(upOutcome.label) && isNegativeOutcomeLabel(downOutcome.label),
+  )
+}
+
 function resolveNeutralSportsButtonAppearance() {
   return {
     className: `
@@ -243,6 +256,43 @@ function resolveSportsButtonAppearance(market: FeaturedSportsButtonMarket) {
     backgroundClassName: resolveSportsTeamFallbackClassName(market.tone === 'home' ? 'team1' : 'team2'),
     backgroundStyle: undefined,
   }
+}
+
+function resolveLiveFeaturedOutcomeAppearance(item: HomeFeaturedEventCard, index: number) {
+  if (!shouldUseLiveFeaturedOutcomeColors(item)) {
+    return null
+  }
+
+  if (index === 0) {
+    const color = item.liveChartConfig?.line_color?.trim()
+    if (!color) {
+      return null
+    }
+
+    const appearance = resolveSportsButtonAppearance({
+      key: 'featured-live-up',
+      conditionId: '',
+      label: 'Up',
+      tone: 'home',
+      color,
+    })
+
+    return {
+      ...appearance,
+      className: `!border-0 ${appearance.className}`,
+    }
+  }
+
+  if (index === 1) {
+    return {
+      className: '!border-0 !bg-secondary/75 text-muted-foreground hover:!bg-[#7A828C] hover:!text-foreground',
+      style: undefined,
+      backgroundClassName: undefined,
+      backgroundStyle: undefined,
+    }
+  }
+
+  return null
 }
 
 function toTitleCase(value: string) {
@@ -492,22 +542,41 @@ function StandardActions({
     return null
   }
 
+  const shouldUseLiveOutcomeColors = shouldUseLiveFeaturedOutcomeColors(item)
+
   return (
     <div className={cn('grid gap-2', stacked ? 'grid-cols-1' : 'grid-cols-2')}>
       {outcomes.slice(0, 2).map((outcome, index) => {
         const isNegative = isNegativeOutcomeLabel(outcome.label) || index === 1
+        const liveOutcomeAppearance = resolveLiveFeaturedOutcomeAppearance(item, index)
 
         return (
           <Button
-            key={outcome.key}
-            variant={isNegative ? 'no' : 'yes'}
+            key={`featured-action-${index}`}
+            variant={liveOutcomeAppearance ? 'outline' : isNegative ? 'no' : 'yes'}
             className={cn(
               `inline-flex h-16 min-w-0 items-center justify-center rounded-lg px-4 text-center text-base font-semibold transition duration-150 active:scale-[98%] md:h-14 md:px-4 md:text-base`,
+              shouldUseLiveOutcomeColors && 'shadow-none',
+              shouldUseLiveOutcomeColors && 'uppercase',
+              liveOutcomeAppearance?.className,
             )}
+            style={liveOutcomeAppearance?.style}
             nativeButton={false}
             render={
-              <Link href={resolveFeaturedOutcomeHref(item.event, outcome, linkedHref)}>
-                <span className="truncate">{outcome.label}</span>
+              <Link
+                href={resolveFeaturedOutcomeHref(item.event, outcome, linkedHref)}
+                className="relative inline-flex size-full items-center justify-center"
+              >
+                {liveOutcomeAppearance?.backgroundClassName || liveOutcomeAppearance?.backgroundStyle ? (
+                  <span
+                    className={cn(
+                      'pointer-events-none absolute inset-0 z-0 rounded-lg opacity-[0.15] transition-opacity group-hover/team-button:opacity-100',
+                      liveOutcomeAppearance.backgroundClassName,
+                    )}
+                    style={liveOutcomeAppearance.backgroundStyle}
+                  />
+                ) : null}
+                <span className="relative z-1 truncate">{outcome.label}</span>
               </Link>
             }
           />
@@ -1737,32 +1806,139 @@ function FeaturedRightRailAction() {
   )
 }
 
+interface HomeFeaturedRolloverQueueState {
+  activeIndex: number
+  events: HomeFeaturedRolloverEvent[]
+}
+
+function buildHomeFeaturedRolloverQueueState(item: HomeFeaturedEventCard): HomeFeaturedRolloverQueueState {
+  return {
+    activeIndex: -1,
+    events: item.targetType === 'series' && item.nextSeriesEvent ? [item.nextSeriesEvent] : [],
+  }
+}
+
 function useHomeFeaturedRolloverItem(item: HomeFeaturedEventCard) {
-  const [rolloverState, setRolloverState] = useState<{ featuredId: string; eventId: string } | null>(null)
-  const nextSeriesEvent = item.targetType === 'series' ? item.nextSeriesEvent : null
+  const locale = useLocale()
+  const [queueState, setQueueState] = useState<HomeFeaturedRolloverQueueState>(() =>
+    buildHomeFeaturedRolloverQueueState(item),
+  )
+  const activeIndex = queueState.activeIndex
+  const rolloverEvents = queueState.events
+  const activeRolloverEvent = activeIndex >= 0 ? (rolloverEvents[activeIndex] ?? null) : null
+  const activeEvent = activeRolloverEvent?.event ?? item.event
+  const nextRolloverEvent = rolloverEvents[activeIndex + 1] ?? null
 
   useEffect(
-    function scheduleFeaturedSeriesRollover() {
-      if (!nextSeriesEvent) {
+    function preloadFutureFeaturedSeriesEvents() {
+      if (item.targetType !== 'series') {
         return
       }
 
-      const endTimestamp = resolveHomeFeaturedEventEndTimestamp(item.event)
+      const futureEventCount = rolloverEvents.length - (activeIndex + 1)
+      if (futureEventCount >= 2) {
+        return
+      }
+
+      const lastKnownEvent = rolloverEvents.at(-1)?.event ?? activeEvent
+      const controller = new AbortController()
+      let retryTimeoutId: number | null = null
+      let isActive = true
+
+      async function loadNextRolloverEvent() {
+        try {
+          const query = new URLSearchParams({
+            currentEventSlug: lastKnownEvent.slug,
+            locale,
+          })
+          const response = await fetch(`/api/home-featured/series-rollover?${query.toString()}`, {
+            cache: 'no-store',
+            signal: controller.signal,
+          })
+          if (!response.ok) {
+            throw new Error(`Featured rollover request failed with ${response.status}`)
+          }
+
+          const payload = (await response.json()) as { nextEvent?: HomeFeaturedRolloverEvent | null }
+          const nextEvent = payload.nextEvent ?? null
+          if (!isActive) {
+            return
+          }
+
+          if (!nextEvent) {
+            retryTimeoutId = window.setTimeout(loadNextRolloverEvent, HOME_FEATURED_ROLLOVER_RETRY_MS)
+            return
+          }
+
+          setQueueState((current) => {
+            if (current.events.some((event) => event.event.id === nextEvent.event.id)) {
+              return current
+            }
+
+            return {
+              ...current,
+              events: [...current.events, nextEvent],
+            }
+          })
+        } catch {
+          if (isActive && !controller.signal.aborted) {
+            retryTimeoutId = window.setTimeout(loadNextRolloverEvent, HOME_FEATURED_ROLLOVER_RETRY_MS)
+          }
+        }
+      }
+
+      void loadNextRolloverEvent()
+
+      return function cancelFutureFeaturedSeriesEventPreload() {
+        isActive = false
+        controller.abort()
+        if (retryTimeoutId != null) {
+          window.clearTimeout(retryTimeoutId)
+        }
+      }
+    },
+    [activeEvent, activeIndex, item.targetType, locale, rolloverEvents],
+  )
+
+  /* oxlint-disable react-you-might-not-need-an-effect/no-external-store-subscription -- The rollover owns an exact market-end timer and a tab-resume listener. */
+  useEffect(
+    function scheduleFeaturedSeriesRollover() {
+      if (!nextRolloverEvent) {
+        return
+      }
+
+      const endTimestamp = resolveHomeFeaturedEventEndTimestamp(activeEvent)
       if (endTimestamp == null) {
         return
       }
-      const scheduledEndTimestamp = endTimestamp
-      const rolloverEvent = nextSeriesEvent
 
       let timeoutId: number | null = null
       function activateNextEvent() {
-        if (Date.now() < scheduledEndTimestamp) {
+        if (!isHomeFeaturedEventEnded(activeEvent, Date.now())) {
           return
         }
-        setRolloverState({ featuredId: item.featuredId, eventId: rolloverEvent.event.id })
+
+        setQueueState((current) => {
+          const currentNextEvent = current.events[current.activeIndex + 1]
+          if (!currentNextEvent || currentNextEvent.event.id !== nextRolloverEvent.event.id) {
+            return current
+          }
+
+          if (current.activeIndex < 0) {
+            return { ...current, activeIndex: 0 }
+          }
+
+          const promotedIndex = current.activeIndex + 1
+          return {
+            ...current,
+            activeIndex: 0,
+            events: current.events.slice(promotedIndex),
+          }
+        })
       }
 
-      timeoutId = window.setTimeout(activateNextEvent, Math.max(0, scheduledEndTimestamp - Date.now()))
+      activateNextEvent()
+      timeoutId = window.setTimeout(activateNextEvent, Math.max(0, endTimestamp - Date.now()))
       document.addEventListener('visibilitychange', activateNextEvent)
 
       return function cancelFeaturedSeriesRollover() {
@@ -1772,25 +1948,22 @@ function useHomeFeaturedRolloverItem(item: HomeFeaturedEventCard) {
         document.removeEventListener('visibilitychange', activateNextEvent)
       }
     },
-    [item.event, item.featuredId, nextSeriesEvent],
+    [activeEvent, nextRolloverEvent],
   )
-
-  const shouldUseNextEvent =
-    nextSeriesEvent &&
-    rolloverState?.featuredId === item.featuredId &&
-    rolloverState.eventId === nextSeriesEvent.event.id
+  /* oxlint-enable react-you-might-not-need-an-effect/no-external-store-subscription */
 
   return useMemo<HomeFeaturedEventCard>(() => {
-    if (!shouldUseNextEvent) {
+    if (!activeRolloverEvent) {
       return item
     }
 
     return {
       ...item,
-      ...nextSeriesEvent,
+      ...activeRolloverEvent,
       contextItems: [],
+      nextSeriesEvent: nextRolloverEvent,
     }
-  }, [item, nextSeriesEvent, shouldUseNextEvent])
+  }, [activeRolloverEvent, item, nextRolloverEvent])
 }
 
 function FeaturedSlide({
@@ -1858,6 +2031,7 @@ function FeaturedSlide({
               showCurrentPriceGuide={false}
               compactBitcoinHeaderPrices
               preserveSeriesContinuity
+              showLiveMarketLink={false}
             />
           ) : item.kind === 'sports' && sportsGraphCard && sportsGraphSelection ? (
             <HomeSportsGameGraph
@@ -2047,7 +2221,7 @@ export default function HomeFeaturedEventsCarousel({
           >
             {items.map((item, index) => (
               <FeaturedSlide
-                key={item.featuredId}
+                key={`${item.featuredId}:${item.event.id}`}
                 item={item}
                 currentTimestamp={currentTimestamp}
                 isActive={index === activeIndex}

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -71,6 +71,8 @@ const HOME_FEATURED_CHART_HEIGHT = 292
 const HOME_FEATURED_CHART_HEIGHT_OFFSET = 20
 const HOME_FEATURED_LIVE_CHART_WIDTH_OFFSET = 24
 const HOME_FEATURED_ROLLOVER_RETRY_MS = 5_000
+const HOME_FEATURED_ROLLOVER_MAX_RETRIES = 6
+const HOME_FEATURED_ROLLOVER_MAX_RETRY_DELAY_MS = 60_000
 const FEATURED_SPORTS_BUTTON_DARK_TEXT_VAR = '--featured-sports-button-dark-text'
 
 type FeaturedSportsButtonTone = 'home' | 'away' | 'draw' | 'neutral'
@@ -1844,6 +1846,24 @@ function useHomeFeaturedRolloverItem(item: HomeFeaturedEventCard) {
       const controller = new AbortController()
       let retryTimeoutId: number | null = null
       let isActive = true
+      let retryAttempt = 0
+
+      function scheduleRolloverRetry() {
+        if (
+          !isActive ||
+          isHomeFeaturedEventEnded(lastKnownEvent, Date.now()) ||
+          retryAttempt >= HOME_FEATURED_ROLLOVER_MAX_RETRIES
+        ) {
+          return
+        }
+
+        const retryDelay = Math.min(
+          HOME_FEATURED_ROLLOVER_RETRY_MS * 2 ** retryAttempt,
+          HOME_FEATURED_ROLLOVER_MAX_RETRY_DELAY_MS,
+        )
+        retryAttempt += 1
+        retryTimeoutId = window.setTimeout(loadNextRolloverEvent, retryDelay)
+      }
 
       async function loadNextRolloverEvent() {
         try {
@@ -1866,7 +1886,7 @@ function useHomeFeaturedRolloverItem(item: HomeFeaturedEventCard) {
           }
 
           if (!nextEvent) {
-            retryTimeoutId = window.setTimeout(loadNextRolloverEvent, HOME_FEATURED_ROLLOVER_RETRY_MS)
+            scheduleRolloverRetry()
             return
           }
 
@@ -1882,7 +1902,7 @@ function useHomeFeaturedRolloverItem(item: HomeFeaturedEventCard) {
           })
         } catch {
           if (isActive && !controller.signal.aborted) {
-            retryTimeoutId = window.setTimeout(loadNextRolloverEvent, HOME_FEATURED_ROLLOVER_RETRY_MS)
+            scheduleRolloverRetry()
           }
         }
       }

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1849,11 +1849,7 @@ function useHomeFeaturedRolloverItem(item: HomeFeaturedEventCard) {
       let retryAttempt = 0
 
       function scheduleRolloverRetry() {
-        if (
-          !isActive ||
-          isHomeFeaturedEventEnded(lastKnownEvent, Date.now()) ||
-          retryAttempt >= HOME_FEATURED_ROLLOVER_MAX_RETRIES
-        ) {
+        if (!isActive || retryAttempt >= HOME_FEATURED_ROLLOVER_MAX_RETRIES) {
           return
         }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -260,6 +260,7 @@ interface EventLiveSeriesChartProps {
   showCurrentPriceGuide?: boolean
   compactBitcoinHeaderPrices?: boolean
   preserveSeriesContinuity?: boolean
+  showLiveMarketLink?: boolean
 }
 
 export default function EventLiveSeriesChart({
@@ -274,6 +275,7 @@ export default function EventLiveSeriesChart({
   showCurrentPriceGuide = true,
   compactBitcoinHeaderPrices = false,
   preserveSeriesContinuity = false,
+  showLiveMarketLink = true,
 }: EventLiveSeriesChartProps) {
   const subscriptionSymbol = useMemo(
     () => normalizeSubscriptionSymbol(config.topic, config.symbol),
@@ -297,6 +299,8 @@ export default function EventLiveSeriesChart({
       showAreaFill={showAreaFill}
       showCurrentPriceGuide={showCurrentPriceGuide}
       compactBitcoinHeaderPrices={compactBitcoinHeaderPrices}
+      preserveSeriesContinuity={preserveSeriesContinuity}
+      showLiveMarketLink={showLiveMarketLink}
     />
   )
 }
@@ -313,6 +317,8 @@ interface EventLiveSeriesChartContentProps {
   showAreaFill: boolean
   showCurrentPriceGuide: boolean
   compactBitcoinHeaderPrices: boolean
+  preserveSeriesContinuity: boolean
+  showLiveMarketLink: boolean
 }
 
 function EventLiveSeriesChartContent({
@@ -327,6 +333,8 @@ function EventLiveSeriesChartContent({
   showAreaFill,
   showCurrentPriceGuide,
   compactBitcoinHeaderPrices,
+  preserveSeriesContinuity,
+  showLiveMarketLink,
 }: EventLiveSeriesChartContentProps) {
   const site = useSiteIdentity()
   const { width: windowWidth } = useWindowSize()
@@ -381,6 +389,7 @@ function EventLiveSeriesChartContent({
     startTimestamp,
   })
   const isEventClosed =
+    !preserveSeriesContinuity &&
     hasExplicitEndTimestamp &&
     (hasResolvedState || Boolean(referenceSnapshot?.is_event_closed) || nowMs >= endTimestamp)
   const chartNowMs = isEventClosed ? endTimestamp : nowMs
@@ -435,10 +444,22 @@ function EventLiveSeriesChartContent({
       ? Math.max(1, Math.round(providedChartWidth))
       : fallbackChartWidth
 
-  const referenceOpeningPrice = useMemo(
+  const snapshotOpeningPrice = useMemo(
     () => normalizeReferencePrice(referenceSnapshot?.opening_price, realtimeTopic),
     [realtimeTopic, referenceSnapshot?.opening_price],
   )
+  const [retainedOpeningPrice, setRetainedOpeningPrice] = useState<number | null>(snapshotOpeningPrice)
+  /* oxlint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-event-handler -- Keep the last confirmed market opening visible while the next exact opening snapshot is still being published. */
+  useEffect(() => {
+    if (!preserveSeriesContinuity || snapshotOpeningPrice == null) {
+      return
+    }
+
+    setRetainedOpeningPrice((current) => (current === snapshotOpeningPrice ? current : snapshotOpeningPrice))
+  }, [preserveSeriesContinuity, snapshotOpeningPrice])
+  /* oxlint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react-you-might-not-need-an-effect/no-event-handler */
+  const referenceOpeningPrice =
+    snapshotOpeningPrice ?? (preserveSeriesContinuity ? retainedOpeningPrice : snapshotOpeningPrice)
   const referenceClosingPrice = useMemo(
     () => normalizeReferencePrice(referenceSnapshot?.closing_price, realtimeTopic),
     [realtimeTopic, referenceSnapshot?.closing_price],
@@ -544,7 +565,8 @@ function EventLiveSeriesChartContent({
     () => findLiveSeriesEvent(seriesEvents, event.slug, nowMs, tradingWindowMs),
     [event.slug, nowMs, seriesEvents, tradingWindowMs],
   )
-  const liveMarketHref = isEventClosed && liveSeriesEvent ? resolveEventPagePath(liveSeriesEvent) : null
+  const liveMarketHref =
+    showLiveMarketLink && isEventClosed && liveSeriesEvent ? resolveEventPagePath(liveSeriesEvent) : null
   const closedFallbackData = useMemo(
     () =>
       buildClosedLiveSeriesData({
@@ -730,10 +752,10 @@ function EventLiveSeriesChartContent({
   }, [axisCurrentPrice, axisPriceDisplayDigits, dataSource])
   const axisInitializationPhase =
     data.length > 0 ? 'realtime-ready' : dataSource.length > 0 ? 'reference-ready' : 'empty'
-  const axisValues = useStableLiveChartAxis(
-    candidateAxisValues,
-    `${event.id}:${realtimeTopic}:${subscriptionSymbol}:${axisInitializationPhase}`,
-  )
+  const chartScopeKey = preserveSeriesContinuity
+    ? `${config.series_slug}:${config.topic}:${config.event_type}:${subscriptionSymbol}`
+    : `${event.id}:${realtimeTopic}:${subscriptionSymbol}`
+  const axisValues = useStableLiveChartAxis(candidateAxisValues, `${chartScopeKey}:${axisInitializationPhase}`)
 
   const currentLineTop = (() => {
     if (currentPrice == null) {
@@ -899,7 +921,7 @@ function EventLiveSeriesChartContent({
                   bottom: LIVE_CHART_MARGIN_BOTTOM,
                   left: LIVE_CHART_MARGIN_LEFT,
                 }}
-                dataSignature={`${event.id}:${realtimeTopic}:${subscriptionSymbol}`}
+                dataSignature={chartScopeKey}
                 xAxisTickCount={isMobile ? 2 : 4}
                 xDomain={liveXAxisDomain}
                 xAxisTickValues={xAxisTickValues}

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
@@ -57,6 +57,9 @@ const LIVE_SERIES_PRICE_SNAPSHOT_STORE_TTL_MS = 10 * 60 * 1000
 const BINANCE_CLOSE_FIRST_REFRESH_DELAY_MS = 65 * 1000
 const BINANCE_CLOSE_REFRESH_INTERVAL_MS = 10 * 1000
 const BINANCE_CLOSE_REFRESH_WINDOW_MS = 5 * 60 * 1000
+const OPENING_PRICE_FIRST_REFRESH_DELAY_MS = 5 * 1000
+const OPENING_PRICE_REFRESH_INTERVAL_MS = 5 * 1000
+const OPENING_PRICE_REFRESH_WINDOW_MS = 2 * 60 * 1000
 const EMPTY_LIVE_SERIES_PRICE_SNAPSHOT: LiveSeriesPriceSnapshotStoreSnapshot = {
   referenceSnapshot: null,
   referenceSnapshotStatus: 'loading',
@@ -103,6 +106,28 @@ function buildLiveSeriesPriceSnapshotQuery({
 
 function buildPersistedLivePriceStorageKey(topic: string, symbol: string) {
   return `${liveSeriesPriceStorageKeyPrefix}:${topic.trim().toLowerCase()}:${symbol.trim().toUpperCase()}`
+}
+
+function resolveRequestedWindowStart(request: LiveSeriesPriceSnapshotRequest) {
+  if (request.startTimestamp != null && request.startTimestamp > 0) {
+    return request.startTimestamp
+  }
+
+  if (request.explicitEndTimestamp == null) {
+    return null
+  }
+
+  return request.explicitEndTimestamp - request.activeWindowMinutes * 60 * 1000
+}
+
+function hasRequestedOpeningPrice(snapshot: LiveSeriesPriceSnapshot | null, request: LiveSeriesPriceSnapshotRequest) {
+  const requestedWindowStart = resolveRequestedWindowStart(request)
+  const openingPrice = Number(snapshot?.opening_price)
+  if (!snapshot || !Number.isFinite(openingPrice) || openingPrice <= 0) {
+    return false
+  }
+
+  return requestedWindowStart == null || snapshot.event_window_start_ms === requestedWindowStart
 }
 
 function getLiveSeriesPriceSnapshotStoreEntry(storeKey: string) {
@@ -276,6 +301,7 @@ function subscribeToLiveSeriesPriceSnapshot(onStoreChange: () => void, request: 
   const entry = getLiveSeriesPriceSnapshotStoreEntry(storeKey)
   entry.listeners.add(onStoreChange)
   let binanceCloseRefreshTimer: ReturnType<typeof setTimeout> | null = null
+  let openingPriceRefreshTimer: ReturnType<typeof setTimeout> | null = null
   let isSubscribed = true
 
   if (syncPersistedLivePriceSnapshot(storeKey, request)) {
@@ -312,6 +338,35 @@ function subscribeToLiveSeriesPriceSnapshot(onStoreChange: () => void, request: 
         Math.max(0, firstRefreshAtMs - Date.now()),
       )
     }
+  }
+
+  async function refreshOpeningPriceUntilAvailable() {
+    if (!isSubscribed || hasRequestedOpeningPrice(entry.snapshot.referenceSnapshot, request)) {
+      return
+    }
+
+    await fetchLiveSeriesPriceSnapshot(storeKey, request)
+    const requestedWindowStart = resolveRequestedWindowStart(request)
+    if (
+      !isSubscribed ||
+      hasRequestedOpeningPrice(entry.snapshot.referenceSnapshot, request) ||
+      requestedWindowStart == null ||
+      Date.now() >= requestedWindowStart + OPENING_PRICE_REFRESH_WINDOW_MS
+    ) {
+      return
+    }
+
+    openingPriceRefreshTimer = setTimeout(refreshOpeningPriceUntilAvailable, OPENING_PRICE_REFRESH_INTERVAL_MS)
+  }
+
+  const requestedWindowStart = resolveRequestedWindowStart(request)
+  if (
+    requestedWindowStart != null &&
+    Date.now() < requestedWindowStart + OPENING_PRICE_REFRESH_WINDOW_MS &&
+    !hasRequestedOpeningPrice(entry.snapshot.referenceSnapshot, request)
+  ) {
+    const firstRefreshAtMs = requestedWindowStart + OPENING_PRICE_FIRST_REFRESH_DELAY_MS
+    openingPriceRefreshTimer = setTimeout(refreshOpeningPriceUntilAvailable, Math.max(0, firstRefreshAtMs - Date.now()))
   }
 
   function refreshSnapshotAfterResume() {
@@ -358,6 +413,9 @@ function subscribeToLiveSeriesPriceSnapshot(onStoreChange: () => void, request: 
     isSubscribed = false
     if (binanceCloseRefreshTimer) {
       clearTimeout(binanceCloseRefreshTimer)
+    }
+    if (openingPriceRefreshTimer) {
+      clearTimeout(openingPriceRefreshTimer)
     }
     entry.listeners.delete(onStoreChange)
     if (entry.listeners.size === 0 && entry.abortController) {

--- a/src/app/api/home-featured/series-rollover/route.ts
+++ b/src/app/api/home-featured/series-rollover/route.ts
@@ -1,0 +1,30 @@
+import { connection, NextResponse } from 'next/server'
+
+import { resolveSupportedLocale } from '@/i18n/locales'
+import { getNextHomeFeaturedSeriesRolloverEvent } from '@/lib/home-featured-events'
+
+export async function GET(request: Request) {
+  await connection()
+  const { searchParams } = new URL(request.url)
+  const currentEventSlug = searchParams.get('currentEventSlug')?.trim() ?? ''
+  const locale = resolveSupportedLocale(searchParams.get('locale'))
+
+  if (!currentEventSlug) {
+    return NextResponse.json({ error: 'currentEventSlug is required' }, { status: 400 })
+  }
+
+  try {
+    const nextEvent = await getNextHomeFeaturedSeriesRolloverEvent(currentEventSlug, locale)
+    return NextResponse.json(
+      { nextEvent },
+      {
+        headers: {
+          'Cache-Control': 'no-store',
+        },
+      },
+    )
+  } catch (error) {
+    console.error('Failed to load the next home featured series event', error)
+    return NextResponse.json({ error: 'Failed to load the next featured event' }, { status: 500 })
+  }
+}

--- a/src/app/api/price-reference/live-series/route.ts
+++ b/src/app/api/price-reference/live-series/route.ts
@@ -317,8 +317,9 @@ export async function GET(request: Request) {
     )
 
     const openingRow =
-      selectMostRecentRowAtOrBefore(openingHistoryRows, eventWindowStartMs) ??
-      selectMostRecentRowAtOrBefore(openingFallbackRows, eventWindowStartMs)
+      openingHistoryRows.find((row) => row.window_end_ms === eventWindowStartMs) ??
+      openingFallbackRows.find((row) => row.window_end_ms === eventWindowStartMs) ??
+      null
     const windowRow = selectClosingRow(
       closingHistoryRows,
       closingHistoryTargetMs,
@@ -331,10 +332,7 @@ export async function GET(request: Request) {
       if (!latestOpeningMarket?.next_window) {
         return null
       }
-      if (
-        eventWindowStartMs >= latestOpeningMarket.next_window.window_start_ms &&
-        eventWindowStartMs < latestOpeningMarket.next_window.window_end_ms
-      ) {
+      if (eventWindowStartMs === latestOpeningMarket.next_window.window_start_ms) {
         return toFiniteNumber(latestOpeningMarket.next_window.opening_reference_price)
       }
       return null
@@ -343,10 +341,7 @@ export async function GET(request: Request) {
       if (!latestMarket?.next_window) {
         return null
       }
-      if (
-        eventWindowStartMs >= latestMarket.next_window.window_start_ms &&
-        eventWindowStartMs < latestMarket.next_window.window_end_ms
-      ) {
+      if (eventWindowStartMs === latestMarket.next_window.window_start_ms) {
         return toFiniteNumber(latestMarket.next_window.opening_reference_price)
       }
       return null

--- a/src/app/api/price-reference/live-series/route.ts
+++ b/src/app/api/price-reference/live-series/route.ts
@@ -317,8 +317,8 @@ export async function GET(request: Request) {
     )
 
     const openingRow =
-      openingHistoryRows.find((row) => row.window_end_ms === eventWindowStartMs) ??
-      openingFallbackRows.find((row) => row.window_end_ms === eventWindowStartMs) ??
+      openingHistoryRows.find((row) => row.window_end_ms === openingHistoryTargetMs) ??
+      openingFallbackRows.find((row) => row.window_end_ms === openingFallbackTargetMs) ??
       null
     const windowRow = selectClosingRow(
       closingHistoryRows,
@@ -332,7 +332,10 @@ export async function GET(request: Request) {
       if (!latestOpeningMarket?.next_window) {
         return null
       }
-      if (eventWindowStartMs === latestOpeningMarket.next_window.window_start_ms) {
+      if (
+        eventWindowStartMs >= latestOpeningMarket.next_window.window_start_ms &&
+        eventWindowStartMs < latestOpeningMarket.next_window.window_end_ms
+      ) {
         return toFiniteNumber(latestOpeningMarket.next_window.opening_reference_price)
       }
       return null
@@ -341,7 +344,10 @@ export async function GET(request: Request) {
       if (!latestMarket?.next_window) {
         return null
       }
-      if (eventWindowStartMs === latestMarket.next_window.window_start_ms) {
+      if (
+        eventWindowStartMs >= latestMarket.next_window.window_start_ms &&
+        eventWindowStartMs < latestMarket.next_window.window_end_ms
+      ) {
         return toFiniteNumber(latestMarket.next_window.opening_reference_price)
       }
       return null

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -346,6 +346,50 @@ function buildHomeFeaturedRolloverEvent(event: Event, locale: SupportedLocale): 
   }
 }
 
+export async function getNextHomeFeaturedSeriesRolloverEvent(
+  currentEventSlug: string,
+  locale: SupportedLocale = DEFAULT_LOCALE,
+) {
+  const { data: currentEvent, error: currentEventError } = await EventRepository.getEventBySlug(
+    currentEventSlug,
+    '',
+    locale,
+  )
+  if (currentEventError) {
+    throw currentEventError
+  }
+  if (!currentEvent?.series_slug) {
+    return null
+  }
+
+  const { data: seriesEvents, error: seriesEventsError } = await EventRepository.getSeriesEventsBySeriesSlug(
+    currentEvent.series_slug,
+  )
+  if (seriesEventsError) {
+    throw seriesEventsError
+  }
+
+  const nextSeriesEntry = findNextHomeFeaturedSeriesEvent(seriesEvents ?? [], currentEvent, Date.now())
+  if (!nextSeriesEntry) {
+    return null
+  }
+
+  const { data: nextEvent, error: nextEventError } = await EventRepository.getEventBySlug(
+    nextSeriesEntry.slug,
+    '',
+    locale,
+  )
+  if (nextEventError) {
+    throw nextEventError
+  }
+  if (!nextEvent) {
+    return null
+  }
+
+  const resolvedNextEvent = await resolveFeaturedSportsEventPayload(nextEvent, locale)
+  return buildHomeFeaturedRolloverEvent(resolvedNextEvent, locale)
+}
+
 async function loadHomeFeaturedContextItems(
   featuredEventIds: string[],
   locale: SupportedLocale,

--- a/src/lib/home-featured-rollover.ts
+++ b/src/lib/home-featured-rollover.ts
@@ -1,5 +1,7 @@
 import type { Event, EventSeriesEntry } from '@/types'
 
+import { isEventResolvedLike } from '@/lib/home-events'
+
 function parseFeaturedTimestamp(value: string | null | undefined) {
   if (!value) {
     return null
@@ -21,12 +23,26 @@ export function resolveHomeFeaturedEventEndTimestamp(event: Event) {
   return timestamps.length > 0 ? Math.max(...timestamps) : null
 }
 
-export function findNextHomeFeaturedSeriesEvent(seriesEvents: EventSeriesEntry[], currentEvent: Event) {
+export function isHomeFeaturedEventEnded(event: Event, nowTimestamp: number | null) {
+  if (event.status === 'resolved' || event.status === 'archived' || event.resolved_at || isEventResolvedLike(event)) {
+    return true
+  }
+
+  const endTimestamp = resolveHomeFeaturedEventEndTimestamp(event)
+  return endTimestamp != null && nowTimestamp != null && nowTimestamp >= endTimestamp
+}
+
+export function findNextHomeFeaturedSeriesEvent(
+  seriesEvents: EventSeriesEntry[],
+  currentEvent: Event,
+  nowTimestamp: number | null = null,
+) {
   const currentEndTimestamp = resolveHomeFeaturedEventEndTimestamp(currentEvent)
   if (currentEndTimestamp == null) {
     return null
   }
 
+  const minimumEndTimestamp = nowTimestamp == null ? currentEndTimestamp : Math.max(currentEndTimestamp, nowTimestamp)
   let nextEvent: EventSeriesEntry | null = null
   let nextEndTimestamp = Number.POSITIVE_INFINITY
 
@@ -40,7 +56,7 @@ export function findNextHomeFeaturedSeriesEvent(seriesEvents: EventSeriesEntry[]
     }
 
     const endTimestamp = parseFeaturedTimestamp(seriesEvent.end_date)
-    if (endTimestamp == null || endTimestamp <= currentEndTimestamp || endTimestamp >= nextEndTimestamp) {
+    if (endTimestamp == null || endTimestamp <= minimumEndTimestamp || endTimestamp >= nextEndTimestamp) {
       continue
     }
 

--- a/tests/unit/homeFeaturedRollover.test.ts
+++ b/tests/unit/homeFeaturedRollover.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from 'vitest'
 
 import type { Event, EventSeriesEntry } from '@/types'
 
-import { findNextHomeFeaturedSeriesEvent, resolveHomeFeaturedEventEndTimestamp } from '@/lib/home-featured-rollover'
+import {
+  findNextHomeFeaturedSeriesEvent,
+  isHomeFeaturedEventEnded,
+  resolveHomeFeaturedEventEndTimestamp,
+} from '@/lib/home-featured-rollover'
 
 function createEvent(): Event {
   return {
@@ -30,6 +34,20 @@ describe('homeFeaturedRollover', () => {
     expect(resolveHomeFeaturedEventEndTimestamp(createEvent())).toBe(Date.parse('2026-08-13T16:05:00.000Z'))
   })
 
+  it('allows rollover as soon as the current event is resolved', () => {
+    expect(
+      isHomeFeaturedEventEnded(
+        createEventWithOverrides({ status: 'resolved', resolved_at: '2026-08-13T16:01:00.000Z' }),
+        Date.parse('2026-08-13T16:02:00.000Z'),
+      ),
+    ).toBe(true)
+  })
+
+  it('treats an active event as ended after its latest market cutoff', () => {
+    expect(isHomeFeaturedEventEnded(createEvent(), Date.parse('2026-08-13T16:05:00.000Z'))).toBe(true)
+    expect(isHomeFeaturedEventEnded(createEvent(), Date.parse('2026-08-13T16:04:59.000Z'))).toBe(false)
+  })
+
   it('selects the nearest active event after the current market', () => {
     const next = findNextHomeFeaturedSeriesEvent(
       [
@@ -42,4 +60,21 @@ describe('homeFeaturedRollover', () => {
 
     expect(next?.id).toBe('next')
   })
+
+  it('skips already expired successors when catching a stale featured card up to live', () => {
+    const next = findNextHomeFeaturedSeriesEvent(
+      [
+        createSeriesEvent('expired-next', '2026-08-13T16:10:00.000Z'),
+        createSeriesEvent('live-next', '2026-08-13T16:15:00.000Z'),
+      ],
+      createEvent(),
+      Date.parse('2026-08-13T16:11:00.000Z'),
+    )
+
+    expect(next?.id).toBe('live-next')
+  })
 })
+
+function createEventWithOverrides(overrides: Partial<Event>): Event {
+  return { ...createEvent(), ...overrides }
+}

--- a/tests/unit/useLiveSeriesPriceSnapshot.test.tsx
+++ b/tests/unit/useLiveSeriesPriceSnapshot.test.tsx
@@ -27,6 +27,7 @@ describe('useLiveSeriesPriceSnapshot', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
@@ -106,5 +107,61 @@ describe('useLiveSeriesPriceSnapshot', () => {
 
     await waitFor(() => expect(result.current.referenceSnapshotStatus).toBe('unavailable'))
     expect(result.current.referenceSnapshot).toBeNull()
+  })
+
+  it('retries five seconds after a new window starts until its opening price is available', async () => {
+    vi.useFakeTimers()
+    const eventStartTimestamp = now
+    const eventEndTimestamp = eventStartTimestamp + 5 * 60 * 1000
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          opening_price: null,
+          event_window_start_ms: eventStartTimestamp,
+          event_window_end_ms: eventEndTimestamp,
+        }),
+      })
+      .mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          opening_price: 123,
+          latest_price: 124,
+          latest_source_timestamp_ms: eventStartTimestamp + 5_000,
+          event_window_start_ms: eventStartTimestamp,
+          event_window_end_ms: eventEndTimestamp,
+        }),
+      })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const config = {
+      series_slug: 'snapshot-opening-retry-test',
+      topic: 'crypto_prices_chainlink',
+      active_window_minutes: 5,
+    } as EventLiveChartConfig
+
+    const { result } = renderHook(() =>
+      useLiveSeriesPriceSnapshot({
+        config,
+        subscriptionSymbol: 'BTC',
+        explicitEndTimestamp: eventEndTimestamp,
+        startTimestamp: eventStartTimestamp,
+      }),
+    )
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(result.current.referenceSnapshot?.opening_price).toBeNull()
+
+    now += 5_000
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(result.current.referenceSnapshot?.opening_price).toBe(123)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes featured market live updates so series rollovers happen on time and charts show the correct opening price. Rollover now fires as soon as the current event resolves instead of at its scheduled end, and the carousel preloads upcoming events via a new API endpoint.

**Key changes**
- Preloading retries with backoff up to six times, continuing past the scheduled end so the next event is ready even when resolution runs late.
- `isHomeFeaturedEventEnded` lets a card roll over on resolve; expired successors are skipped so stale cards catch up to the live event.
- `EventLiveSeriesChart` gains `preserveSeriesContinuity` and `showLiveMarketLink` so the chart, axis, and last confirmed opening price stay stable across rollover and the live market link stays hidden in the carousel.
- `useLiveSeriesPriceSnapshot` re-checks the opening price every 5 seconds for up to 2 minutes after a new window starts.
- The price reference API matches opening rows only when `window_end_ms` equals the event start, preventing mismatched prices.

<sup>Written for commit 2fdf2149f841b05d9e1e64d3a3d18a5192458b7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

