### PR TITLE
fix: recover stale live data websocket connections

### DIFF
--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -29,6 +29,7 @@ import { buildPublicProfilePath, isPlatformMainCategorySlug } from '@/lib/platfo
 import { cn } from '@/lib/utils'
 import {
   closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
   createWebSocketReconnectController,
   probeWebSocketWithPong,
 } from '@/lib/websocket-reconnect'
@@ -86,8 +87,6 @@ const ROW_HEIGHT_ESTIMATE = 64
 const MIN_VISIBLE_ITEMS = 12
 const MAX_VISIBLE_ITEMS = 28
 const DEFAULT_VIEWPORT_HEIGHT = 800
-const WEBSOCKET_PING_INTERVAL_MS = 25000
-const WEBSOCKET_STALE_TIMEOUT_MS = 70000
 
 function clampBaseVisibleCount(viewportHeight: number) {
   const estimate = Math.ceil(viewportHeight / ROW_HEIGHT_ESTIMATE) + 6
@@ -313,8 +312,6 @@ function createLiveActivityStore() {
 
     let isActive = true
     let ws: WebSocket | null = null
-    let lastMessageAt = Date.now()
-    let heartbeatHandle: number | null = null
 
     function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
       return JSON.stringify({
@@ -328,48 +325,12 @@ function createLiveActivityStore() {
       })
     }
 
-    function clearHeartbeat() {
-      if (heartbeatHandle != null) {
-        window.clearInterval(heartbeatHandle)
-        heartbeatHandle = null
-      }
-    }
-
-    function startHeartbeat() {
-      clearHeartbeat()
-      heartbeatHandle = window.setInterval(() => {
-        if (!isActive || !ws) {
-          return
-        }
-        if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
-          const staleSocket = ws
-          ws = null
-          clearHeartbeat()
-          closeWebSocketWhenReady(staleSocket)
-          scheduleReconnect()
-          return
-        }
-        if (ws.readyState === WebSocket.OPEN) {
-          try {
-            ws.send('PING')
-          } catch {
-            const staleSocket = ws
-            ws = null
-            clearHeartbeat()
-            closeWebSocketWhenReady(staleSocket)
-            scheduleReconnect()
-          }
-        }
-      }, WEBSOCKET_PING_INTERVAL_MS)
-    }
-
     function handleOpen(socket: WebSocket) {
       if (socket !== ws) {
         return
       }
-      lastMessageAt = Date.now()
       reconnectController?.markConnected()
-      startHeartbeat()
+      heartbeatController?.markOpen(socket)
       socket.send(buildSubscriptionPayload('subscribe'))
     }
 
@@ -377,7 +338,7 @@ function createLiveActivityStore() {
       if (!isActive || socket !== ws) {
         return
       }
-      lastMessageAt = Date.now()
+      heartbeatController?.markActivity(socket)
 
       let payload: LiveActivityMessage | null = null
       try {
@@ -468,6 +429,7 @@ function createLiveActivityStore() {
     }
 
     let reconnectController: ReturnType<typeof createWebSocketReconnectController> | null = null
+    let heartbeatController: ReturnType<typeof createWebSocketHeartbeatController> | null = null
 
     function clearReconnect() {
       reconnectController?.clearReconnect()
@@ -485,7 +447,7 @@ function createLiveActivityStore() {
       if (socket !== ws) {
         return
       }
-      clearHeartbeat()
+      heartbeatController?.clear()
       if (!isActive) {
         return
       }
@@ -503,6 +465,7 @@ function createLiveActivityStore() {
       socket.onerror = handleError
       socket.onclose = () => handleClose(socket)
       ws = socket
+      heartbeatController?.markConnecting(socket)
     }
 
     reconnectController = createWebSocketReconnectController({
@@ -511,8 +474,17 @@ function createLiveActivityStore() {
       isActive: () => isActive,
       probeWebSocket: probeWebSocketWithPong,
       resetWebSocket: () => {
-        clearHeartbeat()
+        heartbeatController?.clear()
         ws = null
+      },
+    })
+    heartbeatController = createWebSocketHeartbeatController({
+      getWebSocket: () => ws,
+      isActive: () => isActive,
+      onConnectionLost: (socket) => {
+        ws = null
+        closeWebSocketWhenReady(socket)
+        scheduleReconnect()
       },
     })
 
@@ -522,7 +494,7 @@ function createLiveActivityStore() {
     return function teardownLiveActivityStream() {
       isActive = false
       clearReconnect()
-      clearHeartbeat()
+      heartbeatController.clear()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       const socket = ws
       if (socket) {

--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -27,7 +27,11 @@ import { formatDollarValueLabel, formatSharePriceLabel, formatTimeAgo, toMicro }
 import { POLYGON_SCAN_BASE } from '@/lib/network'
 import { buildPublicProfilePath, isPlatformMainCategorySlug } from '@/lib/platform-routing'
 import { cn } from '@/lib/utils'
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketReconnectController,
+  probeWebSocketWithPong,
+} from '@/lib/websocket-reconnect'
 
 type LiveActivityPayload = DataApiActivity & {
   category?: string
@@ -364,6 +368,7 @@ function createLiveActivityStore() {
         return
       }
       lastMessageAt = Date.now()
+      reconnectController?.markConnected()
       startHeartbeat()
       socket.send(buildSubscriptionPayload('subscribe'))
     }
@@ -504,6 +509,7 @@ function createLiveActivityStore() {
       connect,
       getWebSocket: () => ws,
       isActive: () => isActive,
+      probeWebSocket: probeWebSocketWithPong,
       resetWebSocket: () => {
         ws = null
       },

--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -511,6 +511,7 @@ function createLiveActivityStore() {
       isActive: () => isActive,
       probeWebSocket: probeWebSocketWithPong,
       resetWebSocket: () => {
+        clearHeartbeat()
         ws = null
       },
     })

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
@@ -11,7 +11,11 @@ import type {
 import type { Market } from '@/types'
 
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
+  createWebSocketReconnectController,
+} from '@/lib/websocket-reconnect'
 
 type MarketChannelStatus = 'connecting' | 'live' | 'offline'
 type MarketChannelListener = (payload: any) => void
@@ -28,7 +32,6 @@ interface TokenMapping {
 
 const MarketChannelContext = createContext<MarketChannelContextValue | null>(null)
 const WEBSOCKET_PING_INTERVAL_MS = 10000
-const WEBSOCKET_STALE_TIMEOUT_MS = 70000
 
 function buildTokenMapping(markets: Market[]): TokenMapping {
   const tokenIds: string[] = []
@@ -302,51 +305,13 @@ function useMarketChannelConnection({
 
       let isActive = true
       let ws: WebSocket | null = null
-      let lastMessageAt = Date.now()
-      let heartbeatHandle: number | null = null
-
-      function clearHeartbeat() {
-        if (heartbeatHandle != null) {
-          window.clearInterval(heartbeatHandle)
-          heartbeatHandle = null
-        }
-      }
-
-      function startHeartbeat() {
-        clearHeartbeat()
-        heartbeatHandle = window.setInterval(() => {
-          if (!isActive || !ws) {
-            return
-          }
-          if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
-            const staleSocket = ws
-            ws = null
-            clearHeartbeat()
-            closeWebSocketWhenReady(staleSocket)
-            scheduleReconnect()
-            return
-          }
-          if (ws.readyState === WebSocket.OPEN) {
-            try {
-              ws.send('PING')
-            } catch {
-              const staleSocket = ws
-              ws = null
-              clearHeartbeat()
-              closeWebSocketWhenReady(staleSocket)
-              scheduleReconnect()
-            }
-          }
-        }, WEBSOCKET_PING_INTERVAL_MS)
-      }
 
       function handleOpen(socket: WebSocket) {
         if (socket !== ws) {
           return
         }
-        lastMessageAt = Date.now()
         reconnectController?.markConnected()
-        startHeartbeat()
+        heartbeatController?.markOpen(socket)
         setConnectionStatus('connecting')
         socket.send(
           JSON.stringify({
@@ -362,7 +327,7 @@ function useMarketChannelConnection({
         if (!isActive || socket !== ws) {
           return
         }
-        lastMessageAt = Date.now()
+        heartbeatController?.markActivity(socket)
         setConnectionStatus('live')
         let payload: any
         try {
@@ -404,6 +369,7 @@ function useMarketChannelConnection({
       }
 
       let reconnectController: ReturnType<typeof createWebSocketReconnectController> | null = null
+      let heartbeatController: ReturnType<typeof createWebSocketHeartbeatController> | null = null
 
       function clearReconnect() {
         reconnectController?.clearReconnect()
@@ -421,7 +387,7 @@ function useMarketChannelConnection({
         if (socket !== ws) {
           return
         }
-        clearHeartbeat()
+        heartbeatController?.clear()
         if (isActive) {
           setConnectionStatus('offline')
           ws = null
@@ -430,7 +396,7 @@ function useMarketChannelConnection({
       }
 
       function disconnectSocket(socket: WebSocket) {
-        clearHeartbeat()
+        heartbeatController?.clear()
         socket.onopen = null
         socket.onmessage = null
         socket.onerror = null
@@ -449,6 +415,7 @@ function useMarketChannelConnection({
         socket.onerror = () => handleError(socket)
         socket.onclose = () => handleClose(socket)
         ws = socket
+        heartbeatController?.markConnecting(socket)
       }
 
       reconnectController = createWebSocketReconnectController({
@@ -456,8 +423,20 @@ function useMarketChannelConnection({
         getWebSocket: () => ws,
         isActive: () => isActive,
         resetWebSocket: () => {
+          heartbeatController?.clear()
           ws = null
         },
+      })
+      heartbeatController = createWebSocketHeartbeatController({
+        getWebSocket: () => ws,
+        isActive: () => isActive,
+        onConnectionLost: (socket) => {
+          ws = null
+          setConnectionStatus('offline')
+          closeWebSocketWhenReady(socket)
+          scheduleReconnect()
+        },
+        pingIntervalMs: WEBSOCKET_PING_INTERVAL_MS,
       })
 
       connect()
@@ -466,7 +445,7 @@ function useMarketChannelConnection({
       return function teardownMarketChannelConnection() {
         isActive = false
         clearReconnect()
-        clearHeartbeat()
+        heartbeatController.clear()
         document.removeEventListener('visibilitychange', handleVisibilityChange)
         const socket = ws
         if (socket) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
@@ -345,6 +345,7 @@ function useMarketChannelConnection({
           return
         }
         lastMessageAt = Date.now()
+        reconnectController?.markConnected()
         startHeartbeat()
         setConnectionStatus('connecting')
         socket.send(
@@ -452,10 +453,8 @@ function useMarketChannelConnection({
 
       reconnectController = createWebSocketReconnectController({
         connect,
-        disconnectWebSocket: disconnectSocket,
         getWebSocket: () => ws,
         isActive: () => isActive,
-        reconnectOnVisible: true,
         resetWebSocket: () => {
           ws = null
         },

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventActivityWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventActivityWebSocket.ts
@@ -6,6 +6,7 @@ import type { DataApiActivity } from '@/lib/data-api/user'
 
 import {
   closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
   createWebSocketReconnectController,
   probeWebSocketWithPong,
 } from '@/lib/websocket-reconnect'
@@ -21,9 +22,6 @@ interface UseEventActivityWebSocketOptions {
   onActivities: (activities: DataApiActivity[]) => void
   wsUrl: string | undefined
 }
-
-const WEBSOCKET_PING_INTERVAL_MS = 25000
-const WEBSOCKET_STALE_TIMEOUT_MS = 70000
 
 function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe', eventSlug: string) {
   return JSON.stringify({
@@ -57,54 +55,14 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
       const activeWsUrl = wsUrl
       let isActive = true
       let ws: WebSocket | null = null
-      let lastMessageAt = Date.now()
-      let heartbeatHandle: number | null = null
-
-      function clearHeartbeat() {
-        if (heartbeatHandle !== null) {
-          window.clearInterval(heartbeatHandle)
-          heartbeatHandle = null
-        }
-      }
-
-      function startHeartbeat() {
-        clearHeartbeat()
-        heartbeatHandle = window.setInterval(() => {
-          if (!isActive || !ws) {
-            return
-          }
-
-          if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
-            const staleSocket = ws
-            ws = null
-            clearHeartbeat()
-            closeWebSocketWhenReady(staleSocket)
-            scheduleReconnect()
-            return
-          }
-
-          if (ws.readyState === WebSocket.OPEN) {
-            try {
-              ws.send('PING')
-            } catch {
-              const staleSocket = ws
-              ws = null
-              clearHeartbeat()
-              closeWebSocketWhenReady(staleSocket)
-              scheduleReconnect()
-            }
-          }
-        }, WEBSOCKET_PING_INTERVAL_MS)
-      }
 
       function handleOpen(socket: WebSocket) {
         if (socket !== ws) {
           return
         }
 
-        lastMessageAt = Date.now()
         reconnectController?.markConnected()
-        startHeartbeat()
+        heartbeatController?.markOpen(socket)
         socket.send(buildSubscriptionPayload('subscribe', normalizedEventSlug))
       }
 
@@ -113,7 +71,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
           return
         }
 
-        lastMessageAt = Date.now()
+        heartbeatController?.markActivity(socket)
 
         let message: LiveActivityMessage
         try {
@@ -133,6 +91,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
       }
 
       let reconnectController: ReturnType<typeof createWebSocketReconnectController> | null = null
+      let heartbeatController: ReturnType<typeof createWebSocketHeartbeatController> | null = null
 
       function clearReconnect() {
         reconnectController?.clearReconnect()
@@ -151,7 +110,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
           return
         }
 
-        clearHeartbeat()
+        heartbeatController?.clear()
         if (!isActive) {
           return
         }
@@ -170,6 +129,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
         socket.onmessage = (eventMessage) => handleMessage(socket, eventMessage)
         socket.onclose = () => handleClose(socket)
         ws = socket
+        heartbeatController?.markConnecting(socket)
       }
 
       reconnectController = createWebSocketReconnectController({
@@ -178,8 +138,17 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
         isActive: () => isActive,
         probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
-          clearHeartbeat()
+          heartbeatController?.clear()
           ws = null
+        },
+      })
+      heartbeatController = createWebSocketHeartbeatController({
+        getWebSocket: () => ws,
+        isActive: () => isActive,
+        onConnectionLost: (socket) => {
+          ws = null
+          closeWebSocketWhenReady(socket)
+          scheduleReconnect()
         },
       })
 
@@ -189,7 +158,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
       return function unsubscribeFromEventActivity() {
         isActive = false
         clearReconnect()
-        clearHeartbeat()
+        heartbeatController.clear()
         document.removeEventListener('visibilitychange', handleVisibilityChange)
 
         const socket = ws

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventActivityWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventActivityWebSocket.ts
@@ -178,6 +178,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
         isActive: () => isActive,
         probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
+          clearHeartbeat()
           ws = null
         },
       })

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventActivityWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventActivityWebSocket.ts
@@ -4,7 +4,11 @@ import { useEffect, useRef } from 'react'
 
 import type { DataApiActivity } from '@/lib/data-api/user'
 
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketReconnectController,
+  probeWebSocketWithPong,
+} from '@/lib/websocket-reconnect'
 
 interface LiveActivityMessage {
   payload?: DataApiActivity | DataApiActivity[]
@@ -99,6 +103,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
         }
 
         lastMessageAt = Date.now()
+        reconnectController?.markConnected()
         startHeartbeat()
         socket.send(buildSubscriptionPayload('subscribe', normalizedEventSlug))
       }
@@ -171,6 +176,7 @@ export function useEventActivityWebSocket({ eventSlug, onActivities, wsUrl }: Us
         connect,
         getWebSocket: () => ws,
         isActive: () => isActive,
+        probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
           ws = null
         },

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -125,6 +125,9 @@ interface LiveCommentsChannelParams {
   enabled?: boolean
 }
 
+const WEBSOCKET_PING_INTERVAL_MS = 25_000
+const WEBSOCKET_STALE_TIMEOUT_MS = 70_000
+
 export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveCommentsChannelParams) {
   const queryClient = useQueryClient()
   const { wsLiveDataUrl } = usePublicRuntimeConfig()
@@ -148,6 +151,47 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
 
     let isActive = true
     let ws: WebSocket | null = null
+    let lastMessageAt = Date.now()
+    let heartbeatHandle: number | null = null
+
+    function clearHeartbeat() {
+      if (heartbeatHandle !== null) {
+        window.clearInterval(heartbeatHandle)
+        heartbeatHandle = null
+      }
+    }
+
+    function startHeartbeat() {
+      clearHeartbeat()
+      heartbeatHandle = window.setInterval(() => {
+        if (!isActive || !ws) {
+          return
+        }
+
+        if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
+          const staleSocket = ws
+          ws = null
+          clearHeartbeat()
+          setStatus('offline')
+          closeWebSocketWhenReady(staleSocket)
+          scheduleReconnect()
+          return
+        }
+
+        if (ws.readyState === WebSocket.OPEN) {
+          try {
+            ws.send('PING')
+          } catch {
+            const staleSocket = ws
+            ws = null
+            clearHeartbeat()
+            setStatus('offline')
+            closeWebSocketWhenReady(staleSocket)
+            scheduleReconnect()
+          }
+        }
+      }, WEBSOCKET_PING_INTERVAL_MS)
+    }
 
     function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
       return JSON.stringify({
@@ -162,12 +206,14 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       })
     }
 
-    function handleOpen() {
-      if (!ws) {
+    function handleOpen(socket: WebSocket) {
+      if (socket !== ws) {
         return
       }
+      lastMessageAt = Date.now()
       reconnectController?.markConnected()
-      ws.send(buildSubscriptionPayload('subscribe'))
+      startHeartbeat()
+      socket.send(buildSubscriptionPayload('subscribe'))
       setStatus('live')
     }
 
@@ -289,10 +335,11 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       }
     }
 
-    function handleMessage(eventMessage: MessageEvent<string>) {
-      if (!isActive) {
+    function handleMessage(socket: WebSocket, eventMessage: MessageEvent<string>) {
+      if (!isActive || socket !== ws) {
         return
       }
+      lastMessageAt = Date.now()
       setStatus('live')
 
       let payload: LiveCommentsMessage | null = null
@@ -316,8 +363,8 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       }
     }
 
-    function handleError() {
-      if (isActive) {
+    function handleError(socket: WebSocket) {
+      if (isActive && socket === ws) {
         setStatus('offline')
       }
     }
@@ -336,7 +383,12 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       reconnectController?.scheduleReconnect()
     }
 
-    function handleClose() {
+    function handleClose(socket: WebSocket) {
+      if (socket !== ws) {
+        return
+      }
+      clearHeartbeat()
+      ws = null
       if (!isActive) {
         return
       }
@@ -350,10 +402,10 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       }
       setStatus('connecting')
       const socket = new WebSocket(wsUrl)
-      socket.onopen = handleOpen
-      socket.onmessage = handleMessage
-      socket.onerror = handleError
-      socket.onclose = handleClose
+      socket.onopen = () => handleOpen(socket)
+      socket.onmessage = (eventMessage) => handleMessage(socket, eventMessage)
+      socket.onerror = () => handleError(socket)
+      socket.onclose = () => handleClose(socket)
       ws = socket
     }
 
@@ -363,6 +415,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       isActive: () => isActive,
       probeWebSocket: probeWebSocketWithPong,
       resetWebSocket: () => {
+        clearHeartbeat()
         ws = null
       },
     })
@@ -374,6 +427,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       isActive = false
       setStatus('offline')
       clearReconnect()
+      clearHeartbeat()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       const socket = ws
       if (socket) {

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -9,6 +9,7 @@ import { commentMetricsQueryKey } from '@/app/[locale]/(platform)/event/[slug]/_
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import {
   closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
   createWebSocketReconnectController,
   probeWebSocketWithPong,
 } from '@/lib/websocket-reconnect'
@@ -125,9 +126,6 @@ interface LiveCommentsChannelParams {
   enabled?: boolean
 }
 
-const WEBSOCKET_PING_INTERVAL_MS = 25_000
-const WEBSOCKET_STALE_TIMEOUT_MS = 70_000
-
 export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveCommentsChannelParams) {
   const queryClient = useQueryClient()
   const { wsLiveDataUrl } = usePublicRuntimeConfig()
@@ -151,47 +149,6 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
 
     let isActive = true
     let ws: WebSocket | null = null
-    let lastMessageAt = Date.now()
-    let heartbeatHandle: number | null = null
-
-    function clearHeartbeat() {
-      if (heartbeatHandle !== null) {
-        window.clearInterval(heartbeatHandle)
-        heartbeatHandle = null
-      }
-    }
-
-    function startHeartbeat() {
-      clearHeartbeat()
-      heartbeatHandle = window.setInterval(() => {
-        if (!isActive || !ws) {
-          return
-        }
-
-        if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
-          const staleSocket = ws
-          ws = null
-          clearHeartbeat()
-          setStatus('offline')
-          closeWebSocketWhenReady(staleSocket)
-          scheduleReconnect()
-          return
-        }
-
-        if (ws.readyState === WebSocket.OPEN) {
-          try {
-            ws.send('PING')
-          } catch {
-            const staleSocket = ws
-            ws = null
-            clearHeartbeat()
-            setStatus('offline')
-            closeWebSocketWhenReady(staleSocket)
-            scheduleReconnect()
-          }
-        }
-      }, WEBSOCKET_PING_INTERVAL_MS)
-    }
 
     function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
       return JSON.stringify({
@@ -210,9 +167,8 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       if (socket !== ws) {
         return
       }
-      lastMessageAt = Date.now()
       reconnectController?.markConnected()
-      startHeartbeat()
+      heartbeatController?.markOpen(socket)
       socket.send(buildSubscriptionPayload('subscribe'))
       setStatus('live')
     }
@@ -339,7 +295,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       if (!isActive || socket !== ws) {
         return
       }
-      lastMessageAt = Date.now()
+      heartbeatController?.markActivity(socket)
       setStatus('live')
 
       let payload: LiveCommentsMessage | null = null
@@ -370,6 +326,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
     }
 
     let reconnectController: ReturnType<typeof createWebSocketReconnectController> | null = null
+    let heartbeatController: ReturnType<typeof createWebSocketHeartbeatController> | null = null
 
     function clearReconnect() {
       reconnectController?.clearReconnect()
@@ -387,7 +344,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       if (socket !== ws) {
         return
       }
-      clearHeartbeat()
+      heartbeatController?.clear()
       ws = null
       if (!isActive) {
         return
@@ -407,6 +364,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       socket.onerror = () => handleError(socket)
       socket.onclose = () => handleClose(socket)
       ws = socket
+      heartbeatController?.markConnecting(socket)
     }
 
     reconnectController = createWebSocketReconnectController({
@@ -415,8 +373,18 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       isActive: () => isActive,
       probeWebSocket: probeWebSocketWithPong,
       resetWebSocket: () => {
-        clearHeartbeat()
+        heartbeatController?.clear()
         ws = null
+      },
+    })
+    heartbeatController = createWebSocketHeartbeatController({
+      getWebSocket: () => ws,
+      isActive: () => isActive,
+      onConnectionLost: (socket) => {
+        ws = null
+        setStatus('offline')
+        closeWebSocketWhenReady(socket)
+        scheduleReconnect()
       },
     })
 
@@ -427,7 +395,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       isActive = false
       setStatus('offline')
       clearReconnect()
-      clearHeartbeat()
+      heartbeatController.clear()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       const socket = ws
       if (socket) {

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -7,7 +7,11 @@ import type { Comment, User } from '@/types'
 
 import { commentMetricsQueryKey } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useCommentMetrics'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketReconnectController,
+  probeWebSocketWithPong,
+} from '@/lib/websocket-reconnect'
 
 interface LiveCommentProfile {
   baseAddress?: string
@@ -162,6 +166,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       if (!ws) {
         return
       }
+      reconnectController?.markConnected()
       ws.send(buildSubscriptionPayload('subscribe'))
       setStatus('live')
     }
@@ -356,6 +361,7 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       connect,
       getWebSocket: () => ws,
       isActive: () => isActive,
+      probeWebSocket: probeWebSocketWithPong,
       resetWebSocket: () => {
         ws = null
       },

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -31,6 +31,7 @@ interface UseLiveSeriesWebSocketOptions {
 }
 
 const LIVE_DATA_HEARTBEAT_INTERVAL_MS = 25_000
+const LIVE_DATA_STALE_TIMEOUT_MS = 70_000
 
 export function useLiveSeriesWebSocket({
   topic,
@@ -61,6 +62,7 @@ export function useLiveSeriesWebSocket({
       let isActive = true
       let ws: WebSocket | null = null
       let heartbeatInterval: ReturnType<typeof setInterval> | null = null
+      let lastMessageAt = Date.now()
       let previousPriceMessageTimestamp: number | null = null
 
       function stopHeartbeat() {
@@ -91,13 +93,33 @@ export function useLiveSeriesWebSocket({
         if (ws !== socket) {
           return
         }
+        lastMessageAt = Date.now()
         reconnectController?.markConnected()
         setStatus('connecting')
         socket.send(buildSubscriptionPayload('subscribe'))
         stopHeartbeat()
         heartbeatInterval = setInterval(() => {
-          if (ws === socket && socket.readyState === WebSocket.OPEN) {
-            socket.send('PING')
+          if (ws !== socket) {
+            return
+          }
+          if (Date.now() - lastMessageAt > LIVE_DATA_STALE_TIMEOUT_MS) {
+            ws = null
+            stopHeartbeat()
+            setStatus('offline')
+            closeWebSocketWhenReady(socket)
+            scheduleReconnect()
+            return
+          }
+          if (socket.readyState === WebSocket.OPEN) {
+            try {
+              socket.send('PING')
+            } catch {
+              ws = null
+              stopHeartbeat()
+              setStatus('offline')
+              closeWebSocketWhenReady(socket)
+              scheduleReconnect()
+            }
           }
         }, LIVE_DATA_HEARTBEAT_INTERVAL_MS)
       }
@@ -106,6 +128,8 @@ export function useLiveSeriesWebSocket({
         if (!isActive || ws !== socket) {
           return
         }
+        const arrivalTimestamp = Date.now()
+        lastMessageAt = arrivalTimestamp
 
         let payload: any
         try {
@@ -114,7 +138,6 @@ export function useLiveSeriesWebSocket({
           return
         }
 
-        const arrivalTimestamp = Date.now()
         const activeEventEndTimestamp = eventEndTimestampRef.current
         const updates = extractLivePriceUpdates(payload, topic, subscriptionSymbol, arrivalTimestamp)
         const normalizedUpdates = updates

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -5,6 +5,7 @@ import type { DataPoint } from '@/types/PredictionChartTypes'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import {
   closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
   createWebSocketReconnectController,
   probeWebSocketWithPong,
 } from '@/lib/websocket-reconnect'
@@ -29,9 +30,6 @@ interface UseLiveSeriesWebSocketOptions {
   subscriptionSymbol: string
   isLiveView: boolean
 }
-
-const LIVE_DATA_HEARTBEAT_INTERVAL_MS = 25_000
-const LIVE_DATA_STALE_TIMEOUT_MS = 70_000
 
 export function useLiveSeriesWebSocket({
   topic,
@@ -61,16 +59,7 @@ export function useLiveSeriesWebSocket({
 
       let isActive = true
       let ws: WebSocket | null = null
-      let heartbeatInterval: ReturnType<typeof setInterval> | null = null
-      let lastMessageAt = Date.now()
       let previousPriceMessageTimestamp: number | null = null
-
-      function stopHeartbeat() {
-        if (heartbeatInterval) {
-          clearInterval(heartbeatInterval)
-          heartbeatInterval = null
-        }
-      }
 
       function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
         const filters = JSON.stringify({
@@ -93,35 +82,10 @@ export function useLiveSeriesWebSocket({
         if (ws !== socket) {
           return
         }
-        lastMessageAt = Date.now()
         reconnectController?.markConnected()
+        heartbeatController?.markOpen(socket)
         setStatus('connecting')
         socket.send(buildSubscriptionPayload('subscribe'))
-        stopHeartbeat()
-        heartbeatInterval = setInterval(() => {
-          if (ws !== socket) {
-            return
-          }
-          if (Date.now() - lastMessageAt > LIVE_DATA_STALE_TIMEOUT_MS) {
-            ws = null
-            stopHeartbeat()
-            setStatus('offline')
-            closeWebSocketWhenReady(socket)
-            scheduleReconnect()
-            return
-          }
-          if (socket.readyState === WebSocket.OPEN) {
-            try {
-              socket.send('PING')
-            } catch {
-              ws = null
-              stopHeartbeat()
-              setStatus('offline')
-              closeWebSocketWhenReady(socket)
-              scheduleReconnect()
-            }
-          }
-        }, LIVE_DATA_HEARTBEAT_INTERVAL_MS)
       }
 
       function handleMessage(socket: WebSocket, eventMessage: MessageEvent<string>) {
@@ -129,7 +93,6 @@ export function useLiveSeriesWebSocket({
           return
         }
         const arrivalTimestamp = Date.now()
-        lastMessageAt = arrivalTimestamp
 
         let payload: any
         try {
@@ -161,6 +124,7 @@ export function useLiveSeriesWebSocket({
         if (!wsUpdatesForRender.length) {
           return
         }
+        heartbeatController?.markActivity(socket, arrivalTimestamp)
 
         const cadenceTransitionDurationMs = resolveLivePriceTransitionDuration(
           previousPriceMessageTimestamp,
@@ -235,6 +199,7 @@ export function useLiveSeriesWebSocket({
       }
 
       let reconnectController: ReturnType<typeof createWebSocketReconnectController> | null = null
+      let heartbeatController: ReturnType<typeof createWebSocketHeartbeatController> | null = null
 
       function clearReconnect() {
         reconnectController?.clearReconnect()
@@ -256,7 +221,7 @@ export function useLiveSeriesWebSocket({
         if (ws !== socket) {
           return
         }
-        stopHeartbeat()
+        heartbeatController?.clear()
         if (!isActive) {
           return
         }
@@ -274,6 +239,7 @@ export function useLiveSeriesWebSocket({
         socket.onerror = handleError
         socket.onclose = () => handleClose(socket)
         ws = socket
+        heartbeatController?.markConnecting(socket)
       }
 
       reconnectController = createWebSocketReconnectController({
@@ -282,8 +248,18 @@ export function useLiveSeriesWebSocket({
         isActive: () => isActive,
         probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
-          stopHeartbeat()
+          heartbeatController?.clear()
           ws = null
+        },
+      })
+      heartbeatController = createWebSocketHeartbeatController({
+        getWebSocket: () => ws,
+        isActive: () => isActive,
+        onConnectionLost: (socket) => {
+          ws = null
+          setStatus('offline')
+          closeWebSocketWhenReady(socket)
+          scheduleReconnect()
         },
       })
 
@@ -294,7 +270,7 @@ export function useLiveSeriesWebSocket({
       return function cleanupLiveSeriesWebSocket() {
         isActive = false
         setStatus('offline')
-        stopHeartbeat()
+        heartbeatController.clear()
         clearReconnect()
         document.removeEventListener('visibilitychange', handleVisibilityChange)
         const socket = ws

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -3,7 +3,11 @@ import { useEffect, useRef, useState } from 'react'
 import type { DataPoint } from '@/types/PredictionChartTypes'
 
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketReconnectController,
+  probeWebSocketWithPong,
+} from '@/lib/websocket-reconnect'
 
 import {
   appendLivePriceTransition,
@@ -26,7 +30,7 @@ interface UseLiveSeriesWebSocketOptions {
   isLiveView: boolean
 }
 
-const LIVE_DATA_HEARTBEAT_INTERVAL_MS = 5_000
+const LIVE_DATA_HEARTBEAT_INTERVAL_MS = 25_000
 
 export function useLiveSeriesWebSocket({
   topic,
@@ -87,6 +91,7 @@ export function useLiveSeriesWebSocket({
         if (ws !== socket) {
           return
         }
+        reconnectController?.markConnected()
         setStatus('connecting')
         socket.send(buildSubscriptionPayload('subscribe'))
         stopHeartbeat()
@@ -252,7 +257,7 @@ export function useLiveSeriesWebSocket({
         connect,
         getWebSocket: () => ws,
         isActive: () => isActive,
-        reconnectOnVisible: true,
+        probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
           stopHeartbeat()
           ws = null

--- a/src/lib/websocket-reconnect.ts
+++ b/src/lib/websocket-reconnect.ts
@@ -1,25 +1,30 @@
 const DEFAULT_RECONNECT_DELAY_MS = 1500
+const MAX_RECONNECT_DELAY_MS = 30_000
+const RECONNECT_JITTER_RATIO = 0.2
+const CONNECTION_STABLE_MS = 30_000
 
 interface CreateWebSocketReconnectControllerOptions {
   connect: () => void
   delayMs?: number
-  disconnectWebSocket?: (ws: WebSocket) => void
   getWebSocket: () => WebSocket | null
   isActive: () => boolean
-  reconnectOnVisible?: boolean
+  probeWebSocket?: (ws: WebSocket) => Promise<boolean>
   resetWebSocket: () => void
 }
 
 export function createWebSocketReconnectController({
   connect,
   delayMs = DEFAULT_RECONNECT_DELAY_MS,
-  disconnectWebSocket,
   getWebSocket,
   isActive,
-  reconnectOnVisible = false,
+  probeWebSocket,
   resetWebSocket,
 }: CreateWebSocketReconnectControllerOptions) {
   let reconnectTimeout: number | null = null
+  let stableTimeout: number | null = null
+  let reconnectAttempt = 0
+  let probeSocket: WebSocket | null = null
+  let probeGeneration = 0
 
   function isClosedOrClosing(ws: WebSocket | null) {
     return !ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING
@@ -29,25 +34,34 @@ export function createWebSocketReconnectController({
     return isClosedOrClosing(getWebSocket())
   }
 
-  function clearReconnect() {
+  function clearReconnectTimer() {
     if (reconnectTimeout != null) {
       window.clearTimeout(reconnectTimeout)
       reconnectTimeout = null
     }
   }
 
-  function disconnectCurrentWebSocket() {
-    const ws = getWebSocket()
-    if (!ws) {
-      return
+  function clearStableTimer() {
+    if (stableTimeout != null) {
+      window.clearTimeout(stableTimeout)
+      stableTimeout = null
     }
+  }
 
-    resetWebSocket()
-    if (disconnectWebSocket) {
-      disconnectWebSocket(ws)
-      return
-    }
-    closeWebSocketWhenReady(ws)
+  function clearReconnect() {
+    probeGeneration += 1
+    probeSocket = null
+    clearReconnectTimer()
+    clearStableTimer()
+  }
+
+  function markConnected() {
+    clearReconnectTimer()
+    clearStableTimer()
+    stableTimeout = window.setTimeout(() => {
+      stableTimeout = null
+      reconnectAttempt = 0
+    }, CONNECTION_STABLE_MS)
   }
 
   function reconnectIfNeeded() {
@@ -60,10 +74,19 @@ export function createWebSocketReconnectController({
   }
 
   function scheduleReconnect() {
-    clearReconnect()
-    reconnectTimeout = window.setTimeout(() => {
-      reconnectIfNeeded()
-    }, delayMs)
+    if (reconnectTimeout != null) {
+      return
+    }
+    clearStableTimer()
+    const baseDelay = Math.min(MAX_RECONNECT_DELAY_MS, Math.max(1, delayMs) * 2 ** reconnectAttempt)
+    reconnectAttempt += 1
+    reconnectTimeout = window.setTimeout(
+      () => {
+        reconnectTimeout = null
+        reconnectIfNeeded()
+      },
+      baseDelay + randomJitter(Math.ceil(baseDelay * RECONNECT_JITTER_RATIO)),
+    )
   }
 
   function handleVisibilityChange() {
@@ -71,21 +94,106 @@ export function createWebSocketReconnectController({
       if (!isActive()) {
         return
       }
-      if (reconnectOnVisible) {
-        clearReconnect()
-        disconnectCurrentWebSocket()
-        connect()
+      clearReconnectTimer()
+      const ws = getWebSocket()
+      if (isClosedOrClosing(ws)) {
+        reconnectIfNeeded()
         return
       }
-      reconnectIfNeeded()
+      if (!probeWebSocket || !ws || ws.readyState !== WebSocket.OPEN || probeSocket === ws) {
+        return
+      }
+
+      const generation = ++probeGeneration
+      probeSocket = ws
+      void probeWebSocket(ws)
+        .then((healthy) => finishVisibilityProbe(ws, generation, healthy))
+        .catch(() => finishVisibilityProbe(ws, generation, false))
     }
+  }
+
+  function finishVisibilityProbe(ws: WebSocket, generation: number, healthy: boolean) {
+    if (generation !== probeGeneration || probeSocket !== ws) {
+      return
+    }
+    probeSocket = null
+    if (!isActive() || getWebSocket() !== ws) {
+      return
+    }
+    if (healthy) {
+      markConnected()
+      return
+    }
+
+    resetWebSocket()
+    closeWebSocketWhenReady(ws)
+    scheduleReconnect()
   }
 
   return {
     clearReconnect,
     handleVisibilityChange,
+    markConnected,
     scheduleReconnect,
   }
+}
+
+export function probeWebSocketWithPong(ws: WebSocket, timeoutMs = 5_000): Promise<boolean> {
+  if (ws.readyState !== WebSocket.OPEN) {
+    return Promise.resolve(false)
+  }
+
+  return new Promise((resolve) => {
+    let settled = false
+    let timeout: number | null = null
+
+    function finish(healthy: boolean) {
+      if (settled) {
+        return
+      }
+      settled = true
+      if (timeout != null) {
+        window.clearTimeout(timeout)
+      }
+      ws.removeEventListener('message', handleMessage)
+      ws.removeEventListener('close', handleClose)
+      ws.removeEventListener('error', handleError)
+      resolve(healthy)
+    }
+
+    function handleMessage(event: MessageEvent) {
+      if (event.data === 'PONG') {
+        finish(true)
+      }
+    }
+
+    function handleClose() {
+      finish(false)
+    }
+
+    function handleError() {
+      finish(false)
+    }
+
+    ws.addEventListener('message', handleMessage)
+    ws.addEventListener('close', handleClose)
+    ws.addEventListener('error', handleError)
+    timeout = window.setTimeout(() => finish(false), Math.max(1, timeoutMs))
+    try {
+      ws.send('PING')
+    } catch {
+      finish(false)
+    }
+  })
+}
+
+function randomJitter(max: number): number {
+  if (max <= 0 || typeof crypto === 'undefined' || typeof crypto.getRandomValues !== 'function') {
+    return 0
+  }
+  const values = new Uint32Array(1)
+  crypto.getRandomValues(values)
+  return Math.floor((values[0] / 0xffffffff) * (max + 1))
 }
 
 export function closeWebSocketWhenReady(

--- a/src/lib/websocket-reconnect.ts
+++ b/src/lib/websocket-reconnect.ts
@@ -2,6 +2,9 @@ const DEFAULT_RECONNECT_DELAY_MS = 1500
 const MAX_RECONNECT_DELAY_MS = 30_000
 const RECONNECT_JITTER_RATIO = 0.2
 const CONNECTION_STABLE_MS = 30_000
+const DEFAULT_PING_INTERVAL_MS = 25_000
+const DEFAULT_STALE_TIMEOUT_MS = 70_000
+const DEFAULT_OPEN_TIMEOUT_MS = 10_000
 
 interface CreateWebSocketReconnectControllerOptions {
   connect: () => void
@@ -10,6 +13,112 @@ interface CreateWebSocketReconnectControllerOptions {
   isActive: () => boolean
   probeWebSocket?: (ws: WebSocket) => Promise<boolean>
   resetWebSocket: () => void
+}
+
+interface CreateWebSocketHeartbeatControllerOptions {
+  getWebSocket: () => WebSocket | null
+  isActive: () => boolean
+  onConnectionLost: (ws: WebSocket) => void
+  openTimeoutMs?: number
+  pingIntervalMs?: number
+  staleTimeoutMs?: number
+}
+
+export function createWebSocketHeartbeatController({
+  getWebSocket,
+  isActive,
+  onConnectionLost,
+  openTimeoutMs = DEFAULT_OPEN_TIMEOUT_MS,
+  pingIntervalMs = DEFAULT_PING_INTERVAL_MS,
+  staleTimeoutMs = DEFAULT_STALE_TIMEOUT_MS,
+}: CreateWebSocketHeartbeatControllerOptions) {
+  let heartbeatInterval: number | null = null
+  let openingTimeout: number | null = null
+  let lastActivityAt = Date.now()
+
+  function clearHeartbeat() {
+    if (heartbeatInterval !== null) {
+      window.clearInterval(heartbeatInterval)
+      heartbeatInterval = null
+    }
+  }
+
+  function clearOpeningTimeout() {
+    if (openingTimeout !== null) {
+      window.clearTimeout(openingTimeout)
+      openingTimeout = null
+    }
+  }
+
+  function clear() {
+    clearHeartbeat()
+    clearOpeningTimeout()
+  }
+
+  function loseConnection(ws: WebSocket) {
+    if (!isActive() || getWebSocket() !== ws) {
+      return
+    }
+    clear()
+    onConnectionLost(ws)
+  }
+
+  function markConnecting(ws: WebSocket) {
+    clear()
+    openingTimeout = window.setTimeout(
+      () => {
+        openingTimeout = null
+        if (ws.readyState === WebSocket.CONNECTING) {
+          loseConnection(ws)
+        }
+      },
+      Math.max(1, openTimeoutMs),
+    )
+  }
+
+  function markOpen(ws: WebSocket) {
+    if (!isActive() || getWebSocket() !== ws) {
+      return
+    }
+    clearOpeningTimeout()
+    clearHeartbeat()
+    lastActivityAt = Date.now()
+    heartbeatInterval = window.setInterval(
+      () => {
+        if (!isActive() || getWebSocket() !== ws) {
+          clearHeartbeat()
+          return
+        }
+        if (Date.now() - lastActivityAt > staleTimeoutMs) {
+          loseConnection(ws)
+          return
+        }
+        if (ws.readyState !== WebSocket.OPEN) {
+          loseConnection(ws)
+          return
+        }
+        try {
+          ws.send('PING')
+        } catch {
+          loseConnection(ws)
+        }
+      },
+      Math.max(1, pingIntervalMs),
+    )
+  }
+
+  function markActivity(ws: WebSocket, activityAt = Date.now()) {
+    if (isActive() && getWebSocket() === ws) {
+      lastActivityAt = activityAt
+    }
+  }
+
+  return {
+    clear,
+    markActivity,
+    markConnecting,
+    markOpen,
+  }
 }
 
 export function createWebSocketReconnectController({

--- a/src/providers/TradeAlertsProvider.tsx
+++ b/src/providers/TradeAlertsProvider.tsx
@@ -26,14 +26,12 @@ import {
 } from '@/lib/trade-alerts-idb'
 import {
   closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
   createWebSocketReconnectController,
   probeWebSocketWithPong,
 } from '@/lib/websocket-reconnect'
 import { useTradeAlertsStore } from '@/stores/useTradeAlerts'
 import { useUser } from '@/stores/useUser'
-
-const WEBSOCKET_PING_INTERVAL_MS = 25_000
-const WEBSOCKET_STALE_TIMEOUT_MS = 70_000
 
 function extractTradeAlertPayload(value: unknown) {
   if (!value || typeof value !== 'object') {
@@ -254,8 +252,6 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
       navigator.serviceWorker?.addEventListener('message', handleServiceWorkerMessage)
 
       let socket: WebSocket | null = null
-      let lastMessageAt = Date.now()
-      let heartbeatHandle: number | null = null
       let wsUrl: URL
       try {
         wsUrl = new URL(wsLiveDataUrl)
@@ -267,43 +263,6 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
       // with the Community bearer token and verifies that its profile matches.
       wsUrl.searchParams.set('following_profile_id', profileId)
 
-      function clearHeartbeat() {
-        if (heartbeatHandle !== null) {
-          window.clearInterval(heartbeatHandle)
-          heartbeatHandle = null
-        }
-      }
-
-      function startHeartbeat() {
-        clearHeartbeat()
-        heartbeatHandle = window.setInterval(() => {
-          if (!activeRef.current || !socket) {
-            return
-          }
-
-          if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
-            const staleSocket = socket
-            socket = null
-            clearHeartbeat()
-            closeWebSocketWhenReady(staleSocket)
-            reconnectController.scheduleReconnect()
-            return
-          }
-
-          if (socket.readyState === WebSocket.OPEN) {
-            try {
-              socket.send('PING')
-            } catch {
-              const staleSocket = socket
-              socket = null
-              clearHeartbeat()
-              closeWebSocketWhenReady(staleSocket)
-              reconnectController.scheduleReconnect()
-            }
-          }
-        }, WEBSOCKET_PING_INTERVAL_MS)
-      }
-
       function connect() {
         if (!activeRef.current || socket) {
           return
@@ -314,9 +273,8 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
           if (socket !== nextSocket) {
             return
           }
-          lastMessageAt = Date.now()
           reconnectController.markConnected()
-          startHeartbeat()
+          heartbeatController.markOpen(nextSocket)
           nextSocket.send(
             JSON.stringify({
               action: 'subscribe',
@@ -335,7 +293,7 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
           if (socket !== nextSocket) {
             return
           }
-          lastMessageAt = Date.now()
+          heartbeatController.markActivity(nextSocket)
           try {
             void handlePayload(JSON.parse(String(event.data))).catch((error) =>
               console.error('Failed to store WebSocket trade alert', error),
@@ -349,12 +307,13 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
           if (socket !== nextSocket) {
             return
           }
-          clearHeartbeat()
+          heartbeatController.clear()
           socket = null
           if (activeRef.current) {
             reconnectController.scheduleReconnect()
           }
         }
+        heartbeatController.markConnecting(nextSocket)
       }
 
       const reconnectController = createWebSocketReconnectController({
@@ -363,8 +322,17 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         isActive: () => activeRef.current,
         probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
-          clearHeartbeat()
+          heartbeatController.clear()
           socket = null
+        },
+      })
+      const heartbeatController = createWebSocketHeartbeatController({
+        getWebSocket: () => socket,
+        isActive: () => activeRef.current,
+        onConnectionLost: (staleSocket) => {
+          socket = null
+          closeWebSocketWhenReady(staleSocket)
+          reconnectController.scheduleReconnect()
         },
       })
       document.addEventListener('visibilitychange', reconnectController.handleVisibilityChange)
@@ -375,7 +343,7 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         navigator.serviceWorker?.removeEventListener('message', handleServiceWorkerMessage)
         document.removeEventListener('visibilitychange', reconnectController.handleVisibilityChange)
         reconnectController.clearReconnect()
-        clearHeartbeat()
+        heartbeatController.clear()
         if (socket) {
           closeWebSocketWhenReady(socket)
           socket = null

--- a/src/providers/TradeAlertsProvider.tsx
+++ b/src/providers/TradeAlertsProvider.tsx
@@ -32,6 +32,9 @@ import {
 import { useTradeAlertsStore } from '@/stores/useTradeAlerts'
 import { useUser } from '@/stores/useUser'
 
+const WEBSOCKET_PING_INTERVAL_MS = 25_000
+const WEBSOCKET_STALE_TIMEOUT_MS = 70_000
+
 function extractTradeAlertPayload(value: unknown) {
   if (!value || typeof value !== 'object') {
     return value
@@ -251,6 +254,8 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
       navigator.serviceWorker?.addEventListener('message', handleServiceWorkerMessage)
 
       let socket: WebSocket | null = null
+      let lastMessageAt = Date.now()
+      let heartbeatHandle: number | null = null
       let wsUrl: URL
       try {
         wsUrl = new URL(wsLiveDataUrl)
@@ -262,6 +267,43 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
       // with the Community bearer token and verifies that its profile matches.
       wsUrl.searchParams.set('following_profile_id', profileId)
 
+      function clearHeartbeat() {
+        if (heartbeatHandle !== null) {
+          window.clearInterval(heartbeatHandle)
+          heartbeatHandle = null
+        }
+      }
+
+      function startHeartbeat() {
+        clearHeartbeat()
+        heartbeatHandle = window.setInterval(() => {
+          if (!activeRef.current || !socket) {
+            return
+          }
+
+          if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
+            const staleSocket = socket
+            socket = null
+            clearHeartbeat()
+            closeWebSocketWhenReady(staleSocket)
+            reconnectController.scheduleReconnect()
+            return
+          }
+
+          if (socket.readyState === WebSocket.OPEN) {
+            try {
+              socket.send('PING')
+            } catch {
+              const staleSocket = socket
+              socket = null
+              clearHeartbeat()
+              closeWebSocketWhenReady(staleSocket)
+              reconnectController.scheduleReconnect()
+            }
+          }
+        }, WEBSOCKET_PING_INTERVAL_MS)
+      }
+
       function connect() {
         if (!activeRef.current || socket) {
           return
@@ -269,7 +311,12 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         const nextSocket = new WebSocket(wsUrl)
         socket = nextSocket
         nextSocket.onopen = () => {
+          if (socket !== nextSocket) {
+            return
+          }
+          lastMessageAt = Date.now()
           reconnectController.markConnected()
+          startHeartbeat()
           nextSocket.send(
             JSON.stringify({
               action: 'subscribe',
@@ -285,6 +332,10 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
           )
         }
         nextSocket.onmessage = (event) => {
+          if (socket !== nextSocket) {
+            return
+          }
+          lastMessageAt = Date.now()
           try {
             void handlePayload(JSON.parse(String(event.data))).catch((error) =>
               console.error('Failed to store WebSocket trade alert', error),
@@ -295,10 +346,14 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         }
         nextSocket.onerror = () => nextSocket.close()
         nextSocket.onclose = () => {
-          if (socket === nextSocket) {
-            socket = null
+          if (socket !== nextSocket) {
+            return
           }
-          reconnectController.scheduleReconnect()
+          clearHeartbeat()
+          socket = null
+          if (activeRef.current) {
+            reconnectController.scheduleReconnect()
+          }
         }
       }
 
@@ -308,6 +363,7 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         isActive: () => activeRef.current,
         probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
+          clearHeartbeat()
           socket = null
         },
       })
@@ -319,6 +375,7 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         navigator.serviceWorker?.removeEventListener('message', handleServiceWorkerMessage)
         document.removeEventListener('visibilitychange', reconnectController.handleVisibilityChange)
         reconnectController.clearReconnect()
+        clearHeartbeat()
         if (socket) {
           closeWebSocketWhenReady(socket)
           socket = null

--- a/src/providers/TradeAlertsProvider.tsx
+++ b/src/providers/TradeAlertsProvider.tsx
@@ -24,7 +24,11 @@ import {
   putTradeAlert,
   setTradeAlertsNeedsSync,
 } from '@/lib/trade-alerts-idb'
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketReconnectController,
+  probeWebSocketWithPong,
+} from '@/lib/websocket-reconnect'
 import { useTradeAlertsStore } from '@/stores/useTradeAlerts'
 import { useUser } from '@/stores/useUser'
 
@@ -265,6 +269,7 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         const nextSocket = new WebSocket(wsUrl)
         socket = nextSocket
         nextSocket.onopen = () => {
+          reconnectController.markConnected()
           nextSocket.send(
             JSON.stringify({
               action: 'subscribe',
@@ -301,10 +306,10 @@ export default function TradeAlertsProvider({ children }: { children: ReactNode 
         connect,
         getWebSocket: () => socket,
         isActive: () => activeRef.current,
+        probeWebSocket: probeWebSocketWithPong,
         resetWebSocket: () => {
           socket = null
         },
-        reconnectOnVisible: true,
       })
       document.addEventListener('visibilitychange', reconnectController.handleVisibilityChange)
       connect()

--- a/tests/unit/useEventActivityWebSocket.test.tsx
+++ b/tests/unit/useEventActivityWebSocket.test.tsx
@@ -17,6 +17,7 @@ class MockWebSocket {
   onerror: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
   send = vi.fn()
+  private listeners = new Map<string, Set<EventListener>>()
 
   constructor(url: string) {
     this.url = url
@@ -30,6 +31,16 @@ class MockWebSocket {
 
   receive(payload: unknown) {
     this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(payload) }))
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const listeners = this.listeners.get(type) ?? new Set<EventListener>()
+    listeners.add(listener)
+    this.listeners.set(type, listeners)
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    this.listeners.get(type)?.delete(listener)
   }
 
   close() {
@@ -47,12 +58,43 @@ describe('useEventActivityWebSocket', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     if (hiddenDescriptor) {
       Object.defineProperty(document, 'hidden', hiddenDescriptor)
     } else {
       Reflect.deleteProperty(document, 'hidden')
     }
+  })
+
+  it('clears the heartbeat before replacing a socket that fails a visibility probe', async () => {
+    vi.useFakeTimers()
+    const { unmount } = renderHook(() =>
+      useEventActivityWebSocket({
+        eventSlug: 'My-Event',
+        onActivities: vi.fn(),
+        wsUrl: 'wss://ws-live-data.example',
+      }),
+    )
+    const socket = MockWebSocket.instances[0]!
+
+    act(() => socket.open())
+    expect(vi.getTimerCount()).toBe(2)
+
+    act(() => {
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+    expect(vi.getTimerCount()).toBe(3)
+
+    await act(async () => vi.advanceTimersByTime(5_000))
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+    expect(vi.getTimerCount()).toBe(1)
+
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
+    unmount()
   })
 
   it('subscribes by event slug and forwards matched activity payloads', () => {

--- a/tests/unit/useLiveCommentsChannel.test.tsx
+++ b/tests/unit/useLiveCommentsChannel.test.tsx
@@ -22,12 +22,15 @@ class MockWebSocket {
   onmessage: ((event: MessageEvent<string>) => void) | null = null
   onerror: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
+  sentMessages: string[] = []
 
   constructor(readonly url: string | URL) {
     MockWebSocket.instances.push(this)
   }
 
-  send() {}
+  send(payload: string) {
+    this.sentMessages.push(payload)
+  }
 
   close() {
     this.readyState = MockWebSocket.CLOSED
@@ -47,6 +50,7 @@ describe('useLiveCommentsChannel', () => {
 
   afterEach(() => {
     cleanup()
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -66,5 +70,33 @@ describe('useLiveCommentsChannel', () => {
     act(() => MockWebSocket.instances[0]?.emitOpen())
 
     expect(result.current.status).toBe('live')
+  })
+
+  it('reconnects a stale socket while the page remains visible', () => {
+    vi.useFakeTimers()
+    const queryClient = new QueryClient()
+
+    function QueryClientWrapper({ children }: { children: ReactNode }) {
+      return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    }
+
+    const { result } = renderHook(() => useLiveCommentsChannel({ eventSlug: 'event-slug', user: null }), {
+      wrapper: QueryClientWrapper,
+    })
+    const socket = MockWebSocket.instances[0]!
+
+    act(() => socket.emitOpen())
+    act(() => {
+      vi.advanceTimersByTime(75_000)
+    })
+
+    expect(socket.sentMessages).toContain('PING')
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+    expect(result.current.status).toBe('offline')
+
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
   })
 })

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -134,6 +134,26 @@ describe('useLiveSeriesWebSocket', () => {
     vi.useRealTimers()
   })
 
+  it('reconnects a stale RTDS socket while the page remains visible', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(now)
+    const { result, socket, unmount } = mountHook()
+
+    act(() => {
+      vi.advanceTimersByTime(75_000)
+    })
+
+    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
+    expect(result.current.status).toBe('offline')
+
+    act(() => {
+      vi.advanceTimersByTime(2_000)
+    })
+    expect(MockWebSocket.instances).toHaveLength(2)
+    unmount()
+    vi.useRealTimers()
+  })
+
   it('keeps the heartbeat and socket when a healthy stream becomes visible again', () => {
     vi.useFakeTimers()
     const { socket, unmount } = mountHook()

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -134,13 +134,17 @@ describe('useLiveSeriesWebSocket', () => {
     vi.useRealTimers()
   })
 
-  it('reconnects a stale RTDS socket while the page remains visible', () => {
+  it('reconnects a stale RTDS stream even when the socket still answers PONG', () => {
     vi.useFakeTimers()
     vi.setSystemTime(now)
     const { result, socket, unmount } = mountHook()
 
     act(() => {
-      vi.advanceTimersByTime(75_000)
+      vi.advanceTimersByTime(25_000)
+    })
+    act(() => socket.emitRawMessage('PONG'))
+    act(() => {
+      vi.advanceTimersByTime(50_000)
     })
 
     expect(socket.readyState).toBe(MockWebSocket.CLOSED)

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -20,6 +20,7 @@ class MockWebSocket {
   onerror: ((event: Event) => void) | null = null
   onclose: ((event: CloseEvent) => void) | null = null
   sentMessages: string[] = []
+  private listeners = new Map<string, Set<(event: Event) => void>>()
 
   constructor(readonly url: string | URL) {
     MockWebSocket.instances.push(this)
@@ -27,6 +28,20 @@ class MockWebSocket {
 
   send(payload: string) {
     this.sentMessages.push(payload)
+  }
+
+  addEventListener(type: string, listener: EventListener) {
+    const eventListeners = this.listeners.get(type) ?? new Set<(event: Event) => void>()
+    eventListeners.add(listener)
+    this.listeners.set(type, eventListeners)
+  }
+
+  removeEventListener(type: string, listener: EventListener) {
+    this.listeners.get(type)?.delete(listener)
+  }
+
+  private emitEvent(type: string, event: Event) {
+    this.listeners.get(type)?.forEach((listener) => listener(event))
   }
 
   close() {
@@ -40,6 +55,11 @@ class MockWebSocket {
 
   emitMessage(payload: unknown) {
     this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent<string>)
+  }
+
+  emitRawMessage(data: string) {
+    this.onmessage?.({ data } as MessageEvent<string>)
+    this.emitEvent('message', new MessageEvent('message', { data }))
   }
 }
 
@@ -106,7 +126,7 @@ describe('useLiveSeriesWebSocket', () => {
     const { socket, unmount } = mountHook()
 
     act(() => {
-      vi.advanceTimersByTime(5_000)
+      vi.advanceTimersByTime(25_000)
     })
 
     expect(socket.sentMessages.at(-1)).toBe('PING')
@@ -114,17 +134,18 @@ describe('useLiveSeriesWebSocket', () => {
     vi.useRealTimers()
   })
 
-  it('clears the old heartbeat before replacing a visible-tab socket', () => {
+  it('keeps the heartbeat and socket when a healthy stream becomes visible again', () => {
     vi.useFakeTimers()
-    const { unmount } = mountHook()
+    const { socket, unmount } = mountHook()
 
-    expect(vi.getTimerCount()).toBe(1)
+    expect(vi.getTimerCount()).toBe(2)
     act(() => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
-    expect(MockWebSocket.instances).toHaveLength(2)
-    expect(vi.getTimerCount()).toBe(0)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(vi.getTimerCount()).toBe(3)
+    act(() => socket.emitRawMessage('PONG'))
     unmount()
     vi.useRealTimers()
   })
@@ -284,7 +305,7 @@ describe('useLiveSeriesWebSocket', () => {
     expect(result.current.data.some((point) => point[SERIES_KEY] === 100)).toBe(true)
   })
 
-  it('replaces an apparently open socket when the tab becomes visible again', () => {
+  it('does not replace an apparently open socket when the tab becomes visible again', () => {
     const hiddenSpy = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false)
     const { socket } = mountHook()
 
@@ -292,19 +313,17 @@ describe('useLiveSeriesWebSocket', () => {
       document.dispatchEvent(new Event('visibilitychange'))
     })
 
-    expect(socket.readyState).toBe(MockWebSocket.CLOSED)
-    expect(MockWebSocket.instances).toHaveLength(2)
-
-    const resumedSocket = MockWebSocket.instances[1]!
-    act(() => resumedSocket.emitOpen())
-
-    expect(JSON.parse(resumedSocket.sentMessages[0]!)).toMatchObject({
+    expect(socket.readyState).toBe(MockWebSocket.OPEN)
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(JSON.parse(socket.sentMessages[0]!)).toMatchObject({
       action: 'subscribe',
     })
+    expect(socket.sentMessages.at(-1)).toBe('PING')
+    act(() => socket.emitRawMessage('PONG'))
     hiddenSpy.mockRestore()
   })
 
-  it('retains rendered history while replacing the socket after focus returns', () => {
+  it('retains rendered history when the tab becomes visible again', () => {
     const hiddenSpy = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false)
     const { result, socket } = mountHook()
 

--- a/tests/unit/websocketReconnect.test.ts
+++ b/tests/unit/websocketReconnect.test.ts
@@ -1,6 +1,11 @@
-import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import {
+  closeWebSocketWhenReady,
+  createWebSocketReconnectController,
+  probeWebSocketWithPong,
+} from '@/lib/websocket-reconnect'
 
 afterEach(() => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
@@ -15,6 +20,34 @@ function createWebSocketStub(readyState: number) {
     } as unknown as WebSocket,
     close,
     addEventListener,
+  }
+}
+
+function createProbeWebSocket() {
+  const listeners = new Map<string, Set<(event: Event) => void>>()
+  const send = vi.fn()
+  const close = vi.fn()
+  const socket = {
+    readyState: WebSocket.OPEN,
+    send,
+    close,
+    addEventListener: vi.fn((type: string, listener: EventListener) => {
+      const eventListeners = listeners.get(type) ?? new Set<(event: Event) => void>()
+      eventListeners.add(listener)
+      listeners.set(type, eventListeners)
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListener) => {
+      listeners.get(type)?.delete(listener)
+    }),
+  } as unknown as WebSocket
+
+  return {
+    socket,
+    send,
+    close,
+    emit(type: string, event: Event) {
+      listeners.get(type)?.forEach((listener) => listener(event))
+    },
   }
 }
 
@@ -81,30 +114,26 @@ describe('createWebSocketReconnectController', () => {
     hiddenSpy.mockRestore()
   })
 
-  it('forces a fresh socket when a configured stream becomes visible again', () => {
+  it('does not force a fresh socket when an existing stream becomes visible again', () => {
     const hiddenSpy = mockDocumentHidden(false)
     const staleSocket = createWebSocketStub(WebSocket.OPEN).socket
     let ws: WebSocket | null = staleSocket
     const connect = vi.fn()
-    const disconnectWebSocket = vi.fn()
     const resetWebSocket = vi.fn(() => {
       ws = null
     })
 
     const controller = createWebSocketReconnectController({
       connect,
-      disconnectWebSocket,
       getWebSocket: () => ws,
       isActive: () => true,
-      reconnectOnVisible: true,
       resetWebSocket,
     })
 
     controller.handleVisibilityChange()
 
-    expect(resetWebSocket).toHaveBeenCalledTimes(1)
-    expect(disconnectWebSocket).toHaveBeenCalledWith(staleSocket)
-    expect(connect).toHaveBeenCalledTimes(1)
+    expect(resetWebSocket).not.toHaveBeenCalled()
+    expect(connect).not.toHaveBeenCalled()
     hiddenSpy.mockRestore()
   })
 
@@ -120,7 +149,6 @@ describe('createWebSocketReconnectController', () => {
       connect,
       getWebSocket: () => ws,
       isActive: () => true,
-      reconnectOnVisible: true,
       resetWebSocket,
     })
 
@@ -129,5 +157,74 @@ describe('createWebSocketReconnectController', () => {
     expect(connect).not.toHaveBeenCalled()
     expect(resetWebSocket).not.toHaveBeenCalled()
     hiddenSpy.mockRestore()
+  })
+
+  it('probes an open socket with PING and accepts only PONG as proof of life', async () => {
+    vi.useFakeTimers()
+    const probeSocket = createProbeWebSocket()
+    const probe = probeWebSocketWithPong(probeSocket.socket)
+
+    expect(probeSocket.send).toHaveBeenCalledWith('PING')
+    probeSocket.emit('message', new MessageEvent('message', { data: 'PONG' }))
+
+    await expect(probe).resolves.toBe(true)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('reconnects an open socket that does not answer the visibility probe', async () => {
+    vi.useFakeTimers()
+    const hiddenSpy = mockDocumentHidden(false)
+    const { socket, send, close } = createProbeWebSocket()
+    let ws: WebSocket | null = socket
+    const connect = vi.fn()
+    const resetWebSocket = vi.fn(() => {
+      ws = null
+    })
+
+    const controller = createWebSocketReconnectController({
+      connect,
+      getWebSocket: () => ws,
+      isActive: () => true,
+      probeWebSocket: probeWebSocketWithPong,
+      resetWebSocket,
+    })
+
+    controller.handleVisibilityChange()
+    expect(send).toHaveBeenCalledWith('PING')
+
+    vi.advanceTimersByTime(5_000)
+    await Promise.resolve()
+
+    expect(resetWebSocket).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledTimes(1)
+
+    vi.runOnlyPendingTimers()
+    expect(connect).toHaveBeenCalledTimes(1)
+    hiddenSpy.mockRestore()
+  })
+
+  it('uses one bounded exponential reconnect timer and resets after a stable connection', () => {
+    vi.useFakeTimers()
+    const ws = createWebSocketStub(WebSocket.CLOSED).socket
+    const connect = vi.fn()
+    const controller = createWebSocketReconnectController({
+      connect,
+      delayMs: 100,
+      getWebSocket: () => ws,
+      isActive: () => true,
+      resetWebSocket: vi.fn(),
+    })
+
+    controller.scheduleReconnect()
+    controller.scheduleReconnect()
+    expect(vi.getTimerCount()).toBe(1)
+    vi.runOnlyPendingTimers()
+    expect(connect).toHaveBeenCalledTimes(1)
+
+    controller.markConnected()
+    vi.advanceTimersByTime(30_000)
+    controller.scheduleReconnect()
+    vi.runOnlyPendingTimers()
+    expect(connect).toHaveBeenCalledTimes(2)
   })
 })

--- a/tests/unit/websocketReconnect.test.ts
+++ b/tests/unit/websocketReconnect.test.ts
@@ -1,5 +1,6 @@
 import {
   closeWebSocketWhenReady,
+  createWebSocketHeartbeatController,
   createWebSocketReconnectController,
   probeWebSocketWithPong,
 } from '@/lib/websocket-reconnect'
@@ -84,6 +85,57 @@ describe('closeWebSocketWhenReady', () => {
     expect(closingClose).not.toHaveBeenCalled()
     expect(closedClose).not.toHaveBeenCalled()
     expect(closeOpenSocket).not.toHaveBeenCalled()
+  })
+})
+
+describe('createWebSocketHeartbeatController', () => {
+  it('abandons a socket whose opening handshake stalls', () => {
+    vi.useFakeTimers()
+    const socket = {
+      readyState: WebSocket.CONNECTING,
+      send: vi.fn(),
+    } as unknown as WebSocket
+    const onConnectionLost = vi.fn()
+    const controller = createWebSocketHeartbeatController({
+      getWebSocket: () => socket,
+      isActive: () => true,
+      onConnectionLost,
+    })
+
+    controller.markConnecting(socket)
+    vi.advanceTimersByTime(9_999)
+    expect(onConnectionLost).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(1)
+    expect(onConnectionLost).toHaveBeenCalledOnce()
+    expect(onConnectionLost).toHaveBeenCalledWith(socket)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('uses only explicitly marked activity to refresh staleness', () => {
+    vi.useFakeTimers()
+    const send = vi.fn()
+    const socket = {
+      readyState: WebSocket.OPEN,
+      send,
+    } as unknown as WebSocket
+    const onConnectionLost = vi.fn()
+    const controller = createWebSocketHeartbeatController({
+      getWebSocket: () => socket,
+      isActive: () => true,
+      onConnectionLost,
+    })
+
+    controller.markOpen(socket)
+    vi.advanceTimersByTime(25_000)
+    expect(send).toHaveBeenLastCalledWith('PING')
+
+    controller.markActivity(socket)
+    vi.advanceTimersByTime(50_000)
+    expect(onConnectionLost).not.toHaveBeenCalled()
+
+    vi.advanceTimersByTime(25_000)
+    expect(onConnectionLost).toHaveBeenCalledWith(socket)
   })
 })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale live data websocket connections by probing sockets with `PING`/`PONG` and monitoring heartbeat freshness instead of blindly replacing sockets when the tab becomes visible again. The reconnect controller only reconnects a visible-tab socket that fails to answer a `PING` within 5 seconds.

- Streams now close and reconnect when no message arrives within 70 seconds, even while the page stays visible, using a 25-second `PING` interval.
- Sockets that stall in the opening handshake for more than 10 seconds are abandoned.
- Adds bounded exponential reconnect backoff with jitter, resetting after 30 seconds of stable connection.
- Applies the probe and staleness detection across activity feeds, event market channels, comments, live series, and trade alerts.

<sup>Written for commit 278e2f001584fcda5db065554a57ade5ac33a4d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

