### PR TITLE
feat: refine featured and live market charts

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1989,19 +1989,21 @@ function FeaturedSlide({
   item: sourceItem,
   currentTimestamp,
   isActive,
+  isPrevious,
   isNext,
   isChartEnabled,
 }: {
   item: HomeFeaturedEventCard
   currentTimestamp: number | null
   isActive: boolean
+  isPrevious: boolean
   isNext: boolean
   isChartEnabled: boolean
 }) {
   const item = useHomeFeaturedRolloverItem(sourceItem)
   const isMobile = useIsMobile()
   const linkedHref = resolveEventPagePath(item.event)
-  const shouldRenderChart = isChartEnabled && (isActive || isNext)
+  const shouldRenderChart = isChartEnabled && (isPrevious || isActive || isNext)
   const [chartContainerRef, chartContainerWidth] = useElementWidth<HTMLDivElement>(shouldRenderChart)
   const isSingleMarket = item.event.total_markets_count === 1 || item.event.markets.length === 1
   const shouldRenderLiveSeriesChart = Boolean(
@@ -2051,6 +2053,7 @@ function FeaturedSlide({
               compactBitcoinHeaderPrices
               preserveSeriesContinuity
               showLiveMarketLink={false}
+              featuredChartLayout
             />
           ) : item.kind === 'sports' && sportsGraphCard && sportsGraphSelection ? (
             <HomeSportsGameGraph
@@ -2186,6 +2189,7 @@ export default function HomeFeaturedEventsCarousel({
   const [isAutoAdvancePaused, setIsAutoAdvancePaused] = useState(false)
   const hasMultipleItems = items.length > 1
   const activeItem = items[activeIndex]
+  const previousIndex = items.length === 0 ? 0 : (activeIndex - 1 + items.length) % items.length
   const nextIndex = items.length === 0 ? 0 : (activeIndex + 1) % items.length
 
   useEffect(
@@ -2306,6 +2310,7 @@ export default function HomeFeaturedEventsCarousel({
                 item={item}
                 currentTimestamp={currentTimestamp}
                 isActive={index === activeIndex}
+                isPrevious={index === previousIndex}
                 isNext={index === nextIndex}
                 isChartEnabled={isChartNearViewport}
               />

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -77,6 +77,10 @@ const LIVE_AXIS_PRICE_FOLLOW_RATIO = 0.18
 const LIVE_AXIS_SETTLE_RATIO = 0.000_05
 const LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO = 0.000_15
 const LIVE_AXIS_TARGET_TICK_INTERVALS = 6
+const FEATURED_LIVE_X_AXIS_DATA_END_RATIO = 0.6
+const FEATURED_LIVE_WINDOW_MS = 8 * 1000
+const FEATURED_LIVE_X_AXIS_STEP_MS = 4 * 1000
+const FEATURED_LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO = 0.000_05
 
 function resolveNiceLiveAxisStep(rawStep: number, minimumStep: number) {
   const magnitude = 10 ** Math.floor(Math.log10(Math.max(rawStep, minimumStep)))
@@ -96,7 +100,13 @@ function buildLiveAxisTicks(min: number, max: number, step: number, fractionDigi
   return ticks
 }
 
-function buildContinuousLiveAxis(values: number[], currentPrice: number | null, fractionDigits: number): LiveChartAxis {
+function buildContinuousLiveAxis(
+  values: number[],
+  currentPrice: number | null,
+  fractionDigits: number,
+  targetTickIntervals = LIVE_AXIS_TARGET_TICK_INTERVALS,
+  minimumSpanRatio = LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO,
+): LiveChartAxis {
   const minimumStep = 1 / 10 ** Math.max(0, Math.min(6, Math.floor(fractionDigits)))
   const finiteValues = values.filter((value) => Number.isFinite(value))
   if (!finiteValues.length) {
@@ -106,7 +116,7 @@ function buildContinuousLiveAxis(values: number[], currentPrice: number | null, 
   const visibleMin = Math.min(...finiteValues)
   const visibleMax = Math.max(...finiteValues)
   const visibleMidpoint = (visibleMin + visibleMax) / 2
-  const minimumSpan = Math.max(Math.abs(visibleMidpoint) * LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO, minimumStep * 6)
+  const minimumSpan = Math.max(Math.abs(visibleMidpoint) * minimumSpanRatio, minimumStep * 6)
   const visibleSpan = Math.max(minimumSpan, visibleMax - visibleMin)
   const resolvedCurrentPrice = currentPrice != null && Number.isFinite(currentPrice) ? currentPrice : visibleMidpoint
   const followedCenter = visibleMidpoint + (resolvedCurrentPrice - visibleMidpoint) * LIVE_AXIS_PRICE_FOLLOW_RATIO
@@ -118,7 +128,7 @@ function buildContinuousLiveAxis(values: number[], currentPrice: number | null, 
   )
   const min = followedCenter - halfSpan
   const max = followedCenter + halfSpan
-  const tickStep = resolveNiceLiveAxisStep((max - min) / LIVE_AXIS_TARGET_TICK_INTERVALS, minimumStep)
+  const tickStep = resolveNiceLiveAxisStep((max - min) / targetTickIntervals, minimumStep)
 
   return {
     min,
@@ -261,6 +271,7 @@ interface EventLiveSeriesChartProps {
   compactBitcoinHeaderPrices?: boolean
   preserveSeriesContinuity?: boolean
   showLiveMarketLink?: boolean
+  featuredChartLayout?: boolean
 }
 
 export default function EventLiveSeriesChart({
@@ -276,6 +287,7 @@ export default function EventLiveSeriesChart({
   compactBitcoinHeaderPrices = false,
   preserveSeriesContinuity = false,
   showLiveMarketLink = true,
+  featuredChartLayout = false,
 }: EventLiveSeriesChartProps) {
   const subscriptionSymbol = useMemo(
     () => normalizeSubscriptionSymbol(config.topic, config.symbol),
@@ -301,6 +313,7 @@ export default function EventLiveSeriesChart({
       compactBitcoinHeaderPrices={compactBitcoinHeaderPrices}
       preserveSeriesContinuity={preserveSeriesContinuity}
       showLiveMarketLink={showLiveMarketLink}
+      featuredChartLayout={featuredChartLayout}
     />
   )
 }
@@ -319,6 +332,7 @@ interface EventLiveSeriesChartContentProps {
   compactBitcoinHeaderPrices: boolean
   preserveSeriesContinuity: boolean
   showLiveMarketLink: boolean
+  featuredChartLayout: boolean
 }
 
 function EventLiveSeriesChartContent({
@@ -335,11 +349,13 @@ function EventLiveSeriesChartContent({
   compactBitcoinHeaderPrices,
   preserveSeriesContinuity,
   showLiveMarketLink,
+  featuredChartLayout,
 }: EventLiveSeriesChartContentProps) {
   const site = useSiteIdentity()
   const { width: windowWidth } = useWindowSize()
   const liveColor = config.line_color || '#F59E0B'
   const chartHeight = Math.max(260, LIVE_CHART_HEIGHT - Math.max(0, chartHeightOffset))
+  const liveWindowMs = featuredChartLayout ? FEATURED_LIVE_WINDOW_MS : LIVE_WINDOW_MS
   const [activeView, setActiveView] = useState<'live' | 'market'>('live')
   const isLiveView = activeView === 'live'
   const startTimestamp = useMemo(() => parseUtcDate(event.start_date ?? null), [event.start_date])
@@ -589,8 +605,8 @@ function EventLiveSeriesChartContent({
     ],
   )
   const liveFallbackData = useMemo(
-    () => buildLiveSeriesFallbackData(fallbackCurrentPrice, chartNowMs),
-    [chartNowMs, fallbackCurrentPrice],
+    () => buildLiveSeriesFallbackData(fallbackCurrentPrice, chartNowMs, liveWindowMs),
+    [chartNowMs, fallbackCurrentPrice, liveWindowMs],
   )
   const dataSource = useMemo(() => {
     if (!isEventClosed) {
@@ -632,7 +648,7 @@ function EventLiveSeriesChartContent({
       return dataSource
     }
 
-    const domainStart = isEventClosed ? tradingWindowStartMs : chartNowMs - LIVE_WINDOW_MS
+    const domainStart = isEventClosed ? tradingWindowStartMs : chartNowMs - liveWindowMs
     const domainEnd = chartNowMs
     let lastPointBeforeDomainStart: DataPoint | null = null
     const pointsWithinDomain: DataPoint[] = []
@@ -694,7 +710,7 @@ function EventLiveSeriesChartContent({
     }
 
     return next
-  }, [chartNowMs, dataSource, isEventClosed, tradingWindowStartMs])
+  }, [chartNowMs, dataSource, isEventClosed, liveWindowMs, tradingWindowStartMs])
 
   const lastPoint = renderData.at(-1)
   const rawRenderedPrice = lastPoint?.[SERIES_KEY]
@@ -740,7 +756,8 @@ function EventLiveSeriesChartContent({
       ? latestAxisPointPrice
       : currentPrice
   const candidateAxisValues = useMemo(() => {
-    const values = dataSource
+    const axisSource = featuredChartLayout ? renderData : dataSource
+    const values = axisSource
       .map((point) => point[SERIES_KEY])
       .filter((value): value is number => typeof value === 'number' && Number.isFinite(value))
 
@@ -748,8 +765,14 @@ function EventLiveSeriesChartContent({
       values.push(axisCurrentPrice)
     }
 
-    return buildContinuousLiveAxis(values, axisCurrentPrice, axisPriceDisplayDigits)
-  }, [axisCurrentPrice, axisPriceDisplayDigits, dataSource])
+    return buildContinuousLiveAxis(
+      values,
+      axisCurrentPrice,
+      axisPriceDisplayDigits,
+      featuredChartLayout ? 4 : LIVE_AXIS_TARGET_TICK_INTERVALS,
+      featuredChartLayout ? FEATURED_LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO : LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO,
+    )
+  }, [axisCurrentPrice, axisPriceDisplayDigits, dataSource, featuredChartLayout, renderData])
   const axisInitializationPhase =
     data.length > 0 ? 'realtime-ready' : dataSource.length > 0 ? 'reference-ready' : 'empty'
   const chartScopeKey = preserveSeriesContinuity
@@ -801,8 +824,26 @@ function EventLiveSeriesChartContent({
 
   const shouldShowCountdown = hasExplicitEndTimestamp && !isEventClosed && (nowMs <= 0 || countdown.totalSeconds > 0)
 
+  const liveXAxisDomain = useMemo(() => {
+    const startTimestamp = isEventClosed ? tradingWindowStartMs : chartNowMs - liveWindowMs
+    const paddedEndTimestamp = resolveLiveChartPaddedDomainEnd({
+      startTimestamp,
+      endTimestamp: chartNowMs,
+      chartWidth,
+      marginLeft: LIVE_CHART_MARGIN_LEFT,
+      marginRight: LIVE_CHART_MARGIN_RIGHT,
+      rightInset: Math.abs(LIVE_CURRENT_MARKER_OFFSET_X),
+      dataEndRatio: featuredChartLayout ? FEATURED_LIVE_X_AXIS_DATA_END_RATIO : undefined,
+    })
+
+    return {
+      start: new Date(startTimestamp),
+      end: new Date(paddedEndTimestamp),
+    }
+  }, [chartNowMs, chartWidth, featuredChartLayout, isEventClosed, liveWindowMs, tradingWindowStartMs])
+
   const xAxisTickValues = useMemo(() => {
-    const startMs = isEventClosed ? tradingWindowStartMs : chartNowMs - LIVE_WINDOW_MS
+    const startMs = isEventClosed ? tradingWindowStartMs : chartNowMs - liveWindowMs
     if (isEventClosed) {
       const tickCount = isMobile ? 2 : 4
       return Array.from({ length: tickCount }, (_value, index) => {
@@ -811,10 +852,17 @@ function EventLiveSeriesChartContent({
       })
     }
 
-    const firstTickMs = Math.ceil(startMs / LIVE_X_AXIS_STEP_MS) * LIVE_X_AXIS_STEP_MS
+    const xAxisStepMs = featuredChartLayout ? FEATURED_LIVE_X_AXIS_STEP_MS : LIVE_X_AXIS_STEP_MS
+    let firstTickMs = Math.floor(startMs / xAxisStepMs) * xAxisStepMs
+    if (firstTickMs >= startMs) {
+      firstTickMs -= xAxisStepMs
+    }
+    const lastTickMs = featuredChartLayout
+      ? Math.ceil(liveXAxisDomain.end.getTime() / xAxisStepMs) * xAxisStepMs
+      : chartNowMs
     const ticks: Date[] = []
 
-    for (let tickMs = firstTickMs; tickMs <= chartNowMs; tickMs += LIVE_X_AXIS_STEP_MS) {
+    for (let tickMs = firstTickMs; tickMs <= lastTickMs; tickMs += xAxisStepMs) {
       ticks.push(new Date(tickMs))
     }
 
@@ -823,24 +871,15 @@ function EventLiveSeriesChartContent({
     }
 
     return [new Date(startMs), new Date(chartNowMs)]
-  }, [chartNowMs, isEventClosed, isMobile, tradingWindowStartMs])
-
-  const liveXAxisDomain = useMemo(() => {
-    const startTimestamp = isEventClosed ? tradingWindowStartMs : chartNowMs - LIVE_WINDOW_MS
-    const paddedEndTimestamp = resolveLiveChartPaddedDomainEnd({
-      startTimestamp,
-      endTimestamp: chartNowMs,
-      chartWidth,
-      marginLeft: LIVE_CHART_MARGIN_LEFT,
-      marginRight: LIVE_CHART_MARGIN_RIGHT,
-      rightInset: Math.abs(LIVE_CURRENT_MARKER_OFFSET_X),
-    })
-
-    return {
-      start: new Date(startTimestamp),
-      end: new Date(paddedEndTimestamp),
-    }
-  }, [chartNowMs, chartWidth, isEventClosed, tradingWindowStartMs])
+  }, [
+    chartNowMs,
+    featuredChartLayout,
+    isEventClosed,
+    isMobile,
+    liveWindowMs,
+    liveXAxisDomain.end,
+    tradingWindowStartMs,
+  ])
 
   const visibleCountdownUnits = useMemo(
     () =>
@@ -899,6 +938,7 @@ function EventLiveSeriesChartContent({
               utcTimeLabel={utcTimeLabel}
               status={status}
               watermark={watermark}
+              showCountdownLogo={!featuredChartLayout}
             />
 
             <div className="relative z-0">
@@ -939,6 +979,10 @@ function EventLiveSeriesChartContent({
                         hour12: false,
                       })
                 }
+                clipXAxisLabelsToPlot={featuredChartLayout && !isEventClosed}
+                xAxisLabelsRightClipRatio={
+                  featuredChartLayout && !isEventClosed ? FEATURED_LIVE_X_AXIS_DATA_END_RATIO : undefined
+                }
                 showVerticalGrid={false}
                 showHorizontalGrid
                 gridLineStyle="solid"
@@ -947,7 +991,7 @@ function EventLiveSeriesChartContent({
                 xAxisTickFontSize={11}
                 yAxisTickFontSize={11}
                 centerXAxisTickLabels={!isEventClosed}
-                xAxisLabelsRightInset={LIVE_X_AXIS_RIGHT_INSET}
+                xAxisLabelsRightInset={featuredChartLayout && !isEventClosed ? 0 : LIVE_X_AXIS_RIGHT_INSET}
                 alignYAxisLabelsToChartEdge
                 fadeYAxisEdges
                 neutralAxisColors

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
@@ -51,6 +51,7 @@ interface EventLiveSeriesChartHeaderProps {
   utcTimeLabel: string
   status: 'connecting' | 'live' | 'offline'
   watermark: Watermark
+  showCountdownLogo: boolean
 }
 
 const ROLLING_DIGITS = Array.from({ length: 10 }, (_, digit) => digit)
@@ -112,13 +113,16 @@ export default function EventLiveSeriesChartHeader({
   utcTimeLabel,
   status,
   watermark,
+  showCountdownLogo,
 }: EventLiveSeriesChartHeaderProps) {
   const t = useExtracted()
   const liveMarketLabel = isMobile ? t('Live') : t('Go to live market')
   const countdownEndedLogo =
     watermark.iconSvg || watermark.iconImageUrl || watermark.label ? (
       <div
-        className="pointer-events-none flex items-center gap-1 text-xl text-muted-foreground opacity-50 select-none"
+        className={cn(
+          'pointer-events-none relative flex translate-y-0.5 items-center gap-1 text-lg leading-none text-muted-foreground opacity-50 select-none min-[360px]:text-xl sm:text-2xl',
+        )}
         aria-hidden
       >
         {watermark.iconSvg || watermark.iconImageUrl ? (
@@ -128,7 +132,7 @@ export default function EventLiveSeriesChartHeader({
             alt={`${watermark.label} logo`}
             className="size-[1em] **:fill-current **:stroke-current"
             imageClassName="size-[1em] object-contain"
-            size={20}
+            size={24}
           />
         ) : null}
         {watermark.label ? <span className="font-semibold">{watermark.label}</span> : null}
@@ -206,90 +210,96 @@ export default function EventLiveSeriesChartHeader({
         </div>
       </div>
       {shouldShowCountdown ? (
-        <Tooltip>
-          <TooltipTrigger
-            render={
-              <button type="button" className="ml-auto grid shrink-0 justify-items-end gap-1 text-left">
-                <div className="flex items-end gap-0.5 min-[360px]:gap-1 sm:gap-3">
-                  {visibleCountdownUnits.map(({ unit, value }) => (
-                    <div key={unit} className="min-w-6 text-right min-[360px]:min-w-8 sm:min-w-11">
-                      <div
-                        className={cn(
-                          'text-[16px] leading-none font-semibold tabular-nums min-[360px]:text-[18px] sm:text-[22px]',
-                          isTradingWindowActive ? 'text-red-500' : 'text-muted-foreground',
-                        )}
-                      >
-                        <RollingValue value={String(Math.max(0, Math.floor(value))).padStart(2, '0')} />
+        <div className="ml-auto flex shrink-0 items-end gap-1 min-[360px]:gap-2 sm:gap-3">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button type="button" className="grid shrink-0 justify-items-end gap-1 text-left">
+                  <div className="flex items-end gap-0.5 min-[360px]:gap-1 sm:gap-3">
+                    {visibleCountdownUnits.map(({ unit, value }) => (
+                      <div key={unit} className="min-w-6 text-right min-[360px]:min-w-8 sm:min-w-11">
+                        <div
+                          className={cn(
+                            'text-[16px] leading-none font-semibold tabular-nums min-[360px]:text-[18px] sm:text-[22px]',
+                            isTradingWindowActive ? 'text-red-500' : 'text-muted-foreground',
+                          )}
+                        >
+                          <RollingValue value={String(Math.max(0, Math.floor(value))).padStart(2, '0')} />
+                        </div>
+                        <div className="mt-1 text-[8px] font-semibold tracking-[0.08em] text-muted-foreground uppercase min-[360px]:text-[9px] sm:text-2xs">
+                          {countdownLabel(unit, value)}
+                        </div>
                       </div>
-                      <div className="mt-1 text-[8px] font-semibold tracking-[0.08em] text-muted-foreground uppercase min-[360px]:text-[9px] sm:text-2xs">
-                        {countdownLabel(unit, value)}
-                      </div>
-                    </div>
-                  ))}
+                    ))}
+                  </div>
+                  <span className="sr-only">{status}</span>
+                </button>
+              }
+            />
+            <TooltipContent align="end" className="w-72 rounded-xl p-3 text-left">
+              <div className="grid gap-2.5">
+                <div className="flex items-center justify-between gap-3">
+                  <div className="inline-flex items-center gap-2 text-red-500">
+                    <LiveIndicator />
+                    <span className="text-xs font-semibold tracking-[0.08em] uppercase">{t('Live')}</span>
+                  </div>
+                  <div className="text-sm">
+                    <span className="font-semibold text-foreground">{countdownLeftLabel}</span>
+                    <span className="ml-1 text-muted-foreground">left</span>
+                  </div>
                 </div>
-                <span className="sr-only">{status}</span>
-              </button>
+
+                <div className="text-xs text-muted-foreground">Resolution time</div>
+
+                <div className="grid gap-2 text-sm text-foreground">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        `inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs font-semibold`,
+                      )}
+                    >
+                      ET
+                    </span>
+                    <span className="tabular-nums">{etDateLabel}</span>
+                    <span className="ml-auto tabular-nums">{etTimeLabel}</span>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        `inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs font-semibold`,
+                      )}
+                    >
+                      UTC
+                    </span>
+                    <span className="tabular-nums">{utcDateLabel}</span>
+                    <span className="ml-auto tabular-nums">{utcTimeLabel}</span>
+                  </div>
+                </div>
+              </div>
+            </TooltipContent>
+          </Tooltip>
+          {showCountdownLogo && <div className="shrink-0 self-start">{countdownEndedLogo}</div>}
+        </div>
+      ) : liveMarketHref ? (
+        <div className="ml-auto flex shrink-0 items-center gap-1 min-[360px]:gap-2 sm:gap-3">
+          <Button
+            size={isMobile ? 'sm' : 'default'}
+            variant="outline"
+            className={cn(
+              'shrink-0 rounded-full font-semibold shadow-none',
+              isMobile ? 'mr-[-4px] gap-1 text-xs' : 'has-[>svg]:px-3.5',
+            )}
+            nativeButton={false}
+            render={
+              <Link href={liveMarketHref}>
+                <LiveIndicator pingOpacity={0.4} />
+                <span>{liveMarketLabel}</span>
+                <ChevronRightIcon className={isMobile ? 'size-3.5' : 'size-4'} />
+              </Link>
             }
           />
-          <TooltipContent align="end" className="w-72 rounded-xl p-3 text-left">
-            <div className="grid gap-2.5">
-              <div className="flex items-center justify-between gap-3">
-                <div className="inline-flex items-center gap-2 text-red-500">
-                  <LiveIndicator />
-                  <span className="text-xs font-semibold tracking-[0.08em] uppercase">{t('Live')}</span>
-                </div>
-                <div className="text-sm">
-                  <span className="font-semibold text-foreground">{countdownLeftLabel}</span>
-                  <span className="ml-1 text-muted-foreground">left</span>
-                </div>
-              </div>
-
-              <div className="text-xs text-muted-foreground">Resolution time</div>
-
-              <div className="grid gap-2 text-sm text-foreground">
-                <div className="flex items-center gap-2">
-                  <span
-                    className={cn(
-                      `inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs font-semibold`,
-                    )}
-                  >
-                    ET
-                  </span>
-                  <span className="tabular-nums">{etDateLabel}</span>
-                  <span className="ml-auto tabular-nums">{etTimeLabel}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span
-                    className={cn(
-                      `inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs font-semibold`,
-                    )}
-                  >
-                    UTC
-                  </span>
-                  <span className="tabular-nums">{utcDateLabel}</span>
-                  <span className="ml-auto tabular-nums">{utcTimeLabel}</span>
-                </div>
-              </div>
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      ) : liveMarketHref ? (
-        <Button
-          size={isMobile ? 'sm' : 'default'}
-          variant="outline"
-          className={cn(
-            'shrink-0 rounded-full font-semibold shadow-none',
-            isMobile ? 'mr-[-4px] ml-auto gap-1 text-xs' : 'ml-auto has-[>svg]:px-3.5',
-          )}
-          nativeButton={false}
-          render={
-            <Link href={liveMarketHref}>
-              <LiveIndicator pingOpacity={0.4} />
-              <span>{liveMarketLabel}</span>
-              <ChevronRightIcon className={isMobile ? 'size-3.5' : 'size-4'} />
-            </Link>
-          }
-        />
+          {showCountdownLogo && <div className="shrink-0">{countdownEndedLogo}</div>}
+        </div>
       ) : isEventClosed ? (
         <div className="mr-[-4px] ml-auto sm:mr-[-6px]">{countdownEndedLogo}</div>
       ) : null}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
@@ -51,7 +51,7 @@ interface EventLiveSeriesChartHeaderProps {
   utcTimeLabel: string
   status: 'connecting' | 'live' | 'offline'
   watermark: Watermark
-  showCountdownLogo: boolean
+  showCountdownLogo?: boolean
 }
 
 const ROLLING_DIGITS = Array.from({ length: 10 }, (_, digit) => digit)
@@ -113,7 +113,7 @@ export default function EventLiveSeriesChartHeader({
   utcTimeLabel,
   status,
   watermark,
-  showCountdownLogo,
+  showCountdownLogo = true,
 }: EventLiveSeriesChartHeaderProps) {
   const t = useExtracted()
   const liveMarketLabel = isMobile ? t('Live') : t('Go to live market')

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -38,13 +38,18 @@ export interface LiveSeriesPriceHistoryPoint {
   price: number
 }
 
-export function buildLiveSeriesFallbackData(price: number | null, chartEndTimestamp: number) {
+export function buildLiveSeriesFallbackData(
+  price: number | null,
+  chartEndTimestamp: number,
+  windowMs = LIVE_WINDOW_MS,
+) {
   if (price == null || !Number.isFinite(price) || price <= 0 || !Number.isFinite(chartEndTimestamp)) {
     return []
   }
 
   const domainEnd = Math.max(0, chartEndTimestamp)
-  const domainStart = Math.max(0, domainEnd - LIVE_WINDOW_MS)
+  const resolvedWindowMs = Number.isFinite(windowMs) && windowMs > 0 ? windowMs : LIVE_WINDOW_MS
+  const domainStart = Math.max(0, domainEnd - resolvedWindowMs)
 
   return [
     {
@@ -65,6 +70,7 @@ export function resolveLiveChartPaddedDomainEnd({
   marginLeft,
   marginRight,
   rightInset,
+  dataEndRatio,
 }: {
   startTimestamp: number
   endTimestamp: number
@@ -72,9 +78,15 @@ export function resolveLiveChartPaddedDomainEnd({
   marginLeft: number
   marginRight: number
   rightInset: number
+  dataEndRatio?: number
 }) {
   const duration = Math.max(1, endTimestamp - startTimestamp)
   const plotWidth = Math.max(1, chartWidth - marginLeft - marginRight)
+
+  if (dataEndRatio != null && Number.isFinite(dataEndRatio) && dataEndRatio > 0 && dataEndRatio <= 1) {
+    return startTimestamp + duration / dataEndRatio
+  }
+
   const visibleWidth = Math.max(1, plotWidth - Math.max(0, rightInset))
 
   return startTimestamp + (duration * plotWidth) / visibleWidth

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
@@ -46,6 +46,8 @@ const FONT_SIZE_PATTERN = /(\d+(?:\.\d+)?)px/
 const WHITESPACE_PATTERN = /\s/
 const NARROW_CHARACTER_PATTERN = /[ilI1|.,'`]/
 const WIDE_CHARACTER_PATTERN = /[mw@%&]/i
+const SPORTS_LEGEND_CURSOR_RESPONSE_MS = 280
+const SPORTS_LEGEND_CURSOR_MAX_ANIMATION_MS = 800
 
 interface SportsLegendTextMeasurements {
   nameWidthsByKey: Map<string, number>
@@ -148,6 +150,147 @@ function createSportsLegendTextMeasurementStore({
     getSnapshot,
     subscribe,
   }
+}
+
+function interpolateSportsLegendCursor(
+  current: PredictionChartCursorSnapshot,
+  target: PredictionChartCursorSnapshot,
+  progress: number,
+) {
+  const values: Record<string, number> = {}
+  const keys = new Set([...Object.keys(current.values), ...Object.keys(target.values)])
+
+  keys.forEach((key) => {
+    const currentValue = current.values[key]
+    const targetValue = target.values[key]
+
+    if (typeof currentValue === 'number' && typeof targetValue === 'number') {
+      values[key] = currentValue + (targetValue - currentValue) * progress
+    } else if (typeof targetValue === 'number') {
+      values[key] = targetValue
+    } else if (typeof currentValue === 'number') {
+      values[key] = currentValue
+    }
+  })
+
+  return {
+    date: new Date(current.date.getTime() + (target.date.getTime() - current.date.getTime()) * progress),
+    values,
+  } satisfies PredictionChartCursorSnapshot
+}
+
+function useLaggedSportsLegendCursor({
+  cursorSnapshot,
+  latestSnapshot,
+  latestTimestamp,
+}: {
+  cursorSnapshot: PredictionChartCursorSnapshot | null
+  latestSnapshot: Record<string, number>
+  latestTimestamp: number | null
+}) {
+  const [displayedSnapshot, setDisplayedSnapshot] = useState<PredictionChartCursorSnapshot | null>(null)
+  const targetRef = useRef<PredictionChartCursorSnapshot | null>(cursorSnapshot)
+  const displayedRef = useRef<PredictionChartCursorSnapshot | null>(null)
+  const animationFrameRef = useRef<number | null>(null)
+  const lastFrameTimestampRef = useRef<number | null>(null)
+  const animationStartTimestampRef = useRef<number | null>(null)
+  const baselineSnapshot = useMemo<PredictionChartCursorSnapshot | null>(() => {
+    if (latestTimestamp == null || !Number.isFinite(latestTimestamp)) {
+      return null
+    }
+
+    return {
+      date: new Date(latestTimestamp),
+      values: latestSnapshot,
+    }
+  }, [latestSnapshot, latestTimestamp])
+
+  useEffect(() => {
+    targetRef.current = cursorSnapshot
+
+    if (!cursorSnapshot) {
+      displayedRef.current = null
+      setDisplayedSnapshot(null)
+      if (animationFrameRef.current != null) {
+        cancelAnimationFrame(animationFrameRef.current)
+        animationFrameRef.current = null
+      }
+      lastFrameTimestampRef.current = null
+      animationStartTimestampRef.current = null
+      return
+    }
+
+    if (!displayedRef.current) {
+      displayedRef.current = baselineSnapshot ?? cursorSnapshot
+      setDisplayedSnapshot(displayedRef.current)
+    }
+
+    if (typeof window === 'undefined' || typeof window.requestAnimationFrame !== 'function') {
+      displayedRef.current = cursorSnapshot
+      setDisplayedSnapshot(cursorSnapshot)
+      animationStartTimestampRef.current = null
+      return
+    }
+
+    if (animationFrameRef.current != null) {
+      return
+    }
+
+    function animate(timestamp: number) {
+      const current = displayedRef.current
+      const target = targetRef.current
+      if (!current || !target) {
+        animationFrameRef.current = null
+        lastFrameTimestampRef.current = null
+        animationStartTimestampRef.current = null
+        return
+      }
+
+      animationStartTimestampRef.current ??= timestamp
+      const previousTimestamp = lastFrameTimestampRef.current ?? timestamp
+      const elapsedMs = Math.min(64, Math.max(0, timestamp - previousTimestamp))
+      lastFrameTimestampRef.current = timestamp
+      const progress = 1 - Math.exp(-elapsedMs / SPORTS_LEGEND_CURSOR_RESPONSE_MS)
+      const next = interpolateSportsLegendCursor(current, target, progress)
+      const remainingDateMs = Math.abs(target.date.getTime() - next.date.getTime())
+      const remainingValue = Math.max(
+        0,
+        ...Object.keys(target.values).map((key) => Math.abs((target.values[key] ?? 0) - (next.values[key] ?? 0))),
+      )
+      const animationElapsedMs = timestamp - animationStartTimestampRef.current
+
+      if (
+        animationElapsedMs >= SPORTS_LEGEND_CURSOR_MAX_ANIMATION_MS ||
+        (remainingDateMs <= 1 && remainingValue <= 0.01)
+      ) {
+        displayedRef.current = target
+        setDisplayedSnapshot(target)
+        animationFrameRef.current = null
+        lastFrameTimestampRef.current = null
+        animationStartTimestampRef.current = null
+        return
+      }
+
+      displayedRef.current = next
+      setDisplayedSnapshot(next)
+      animationFrameRef.current = window.requestAnimationFrame(animate)
+    }
+
+    animationFrameRef.current = window.requestAnimationFrame(animate)
+  }, [baselineSnapshot, cursorSnapshot])
+
+  useEffect(
+    () => () => {
+      if (animationFrameRef.current != null) {
+        cancelAnimationFrame(animationFrameRef.current)
+      }
+      animationStartTimestampRef.current = null
+      lastFrameTimestampRef.current = null
+    },
+    [],
+  )
+
+  return displayedSnapshot
 }
 
 export function useSportsGameGraphChartSettings() {
@@ -551,6 +694,12 @@ export function useSportsGameGraphHeroLegend({
   positionedLegendLayout: SportsPositionedLegendLayout
   usesPositionedSeriesLegend: boolean
 }) {
+  const latestTimestamp = chartData.at(-1)?.date.getTime() ?? null
+  const legendCursorSnapshot = useLaggedSportsLegendCursor({
+    cursorSnapshot,
+    latestSnapshot,
+    latestTimestamp,
+  })
   const heroLegendSeriesWithValues = useMemo(() => {
     if (!canRenderPositionedSeriesLegend) {
       return []
@@ -558,7 +707,7 @@ export function useSportsGameGraphHeroLegend({
 
     return chartSeries
       .map((seriesItem) => {
-        const hoveredValue = cursorSnapshot?.values?.[seriesItem.key]
+        const hoveredValue = legendCursorSnapshot?.values?.[seriesItem.key]
         const value =
           typeof hoveredValue === 'number' && Number.isFinite(hoveredValue)
             ? hoveredValue
@@ -570,7 +719,7 @@ export function useSportsGameGraphHeroLegend({
         return { ...seriesItem, value }
       })
       .filter((entry): entry is { key: string; name: string; color: string; value: number } => entry !== null)
-  }, [canRenderPositionedSeriesLegend, chartSeries, cursorSnapshot, latestSnapshot])
+  }, [canRenderPositionedSeriesLegend, chartSeries, latestSnapshot, legendCursorSnapshot])
 
   const legendTextMeasurementStore = useMemo(
     () =>
@@ -669,7 +818,7 @@ export function useSportsGameGraphHeroLegend({
     const domainStart = Number.isFinite(explicitStart) ? explicitStart : firstTimestamp
     const domainEndCandidate = Number.isFinite(explicitEnd) ? explicitEnd : lastTimestamp
     const domainEnd = Math.max(domainStart + 1, domainEndCandidate)
-    const hoveredTimestampRaw = cursorSnapshot?.date.getTime() ?? lastTimestamp
+    const hoveredTimestampRaw = legendCursorSnapshot?.date.getTime() ?? lastTimestamp
     const hoveredTimestamp = Math.max(firstTimestamp, Math.min(lastTimestamp, hoveredTimestampRaw))
 
     const xSpan = Math.max(1, domainEnd - domainStart)
@@ -752,9 +901,9 @@ export function useSportsGameGraphHeroLegend({
     chartSeries,
     chartWidth,
     chartXDomain,
-    cursorSnapshot?.date,
     heroLegendSeriesWithValues,
     canRenderPositionedSeriesLegend,
+    legendCursorSnapshot?.date,
     positionedLegendLayout,
   ])
 
@@ -762,7 +911,7 @@ export function useSportsGameGraphHeroLegend({
     () =>
       chartSeries
         .map((seriesItem) => {
-          const hoveredValue = cursorSnapshot?.values?.[seriesItem.key]
+          const hoveredValue = legendCursorSnapshot?.values?.[seriesItem.key]
           const value =
             typeof hoveredValue === 'number' && Number.isFinite(hoveredValue)
               ? hoveredValue
@@ -775,7 +924,7 @@ export function useSportsGameGraphHeroLegend({
           return { ...seriesItem, value }
         })
         .filter((entry): entry is { key: string; name: string; color: string; value: number } => entry !== null),
-    [chartSeries, cursorSnapshot, latestSnapshot],
+    [chartSeries, latestSnapshot, legendCursorSnapshot],
   )
 
   return {

--- a/src/components/PredictionChart.tsx
+++ b/src/components/PredictionChart.tsx
@@ -190,6 +190,8 @@ export default function PredictionChart({
   xAxisTickFontSize = 11,
   yAxisTickFontSize = 11,
   centerXAxisTickLabels = false,
+  clipXAxisLabelsToPlot = false,
+  xAxisLabelsRightClipRatio,
   xAxisLabelsRightInset = 0,
   alignYAxisLabelsToChartEdge = false,
   fadeYAxisEdges: _fadeYAxisEdges = false,
@@ -401,7 +403,10 @@ export default function PredictionChart({
     const explicitTicks = xAxisTickValues
       ?.filter((tick) => {
         const timestamp = tick.getTime()
-        return Number.isFinite(timestamp) && timestamp >= domainBounds.start && timestamp <= domainBounds.end
+        return (
+          Number.isFinite(timestamp) &&
+          (clipXAxisLabelsToPlot || (timestamp >= domainBounds.start && timestamp <= domainBounds.end))
+        )
       })
       .sort((left, right) => left.getTime() - right.getTime())
 
@@ -414,7 +419,7 @@ export default function PredictionChart({
       const progress = count === 1 ? 0 : index / (count - 1)
       return new Date(domainBounds.start + (domainBounds.end - domainBounds.start) * progress)
     })
-  }, [domainBounds.end, domainBounds.start, xAxisTickCount, xAxisTickValues])
+  }, [clipXAxisLabelsToPlot, domainBounds.end, domainBounds.start, xAxisTickCount, xAxisTickValues])
 
   const totalDurationHours = (domainBounds.end - domainBounds.start) / 36e5
   const formatXAxisTick = useCallback(
@@ -536,6 +541,8 @@ export default function PredictionChart({
       xAxisTickFontSize,
       yAxisTickFontSize,
       centerXAxisTickLabels,
+      clipXAxisLabelsToPlot,
+      xAxisLabelsRightClipRatio: xAxisLabelsRightClipRatio ?? null,
       xAxisLabelsRightInset,
       gridLineStyle,
       gridLineColor,
@@ -594,6 +601,8 @@ export default function PredictionChart({
       axisLabelColor,
       axisLabelOpacity,
       centerXAxisTickLabels,
+      clipXAxisLabelsToPlot,
+      xAxisLabelsRightClipRatio,
       resolvedCursor,
       cursorGuideColor,
       cursorGuideTop,

--- a/src/components/PredictionChartCanvasRenderer.ts
+++ b/src/components/PredictionChartCanvasRenderer.ts
@@ -52,6 +52,8 @@ export interface PredictionChartCanvasFrame {
   xAxisTickFontSize: number
   yAxisTickFontSize: number
   centerXAxisTickLabels: boolean
+  clipXAxisLabelsToPlot: boolean
+  xAxisLabelsRightClipRatio: number | null
   xAxisLabelsRightInset: number
   gridLineStyle: 'dashed' | 'solid'
   gridLineColor: string
@@ -553,14 +555,27 @@ function drawAxes(context: CanvasRenderingContext2D, frame: PredictionChartCanva
     context.font = `${frame.xAxisTickFontSize}px Arial, sans-serif`
     context.textBaseline = 'top'
     const labelWidth = Math.max(1, innerWidth - frame.xAxisLabelsRightInset)
+    if (frame.clipXAxisLabelsToPlot) {
+      context.save()
+      context.beginPath()
+      const rightClipRatio =
+        frame.xAxisLabelsRightClipRatio == null ? 1 : Math.max(0, Math.min(1, frame.xAxisLabelsRightClipRatio))
+      context.rect(frame.margin.left, 0, Math.max(1, innerWidth * rightClipRatio), frame.height)
+      context.clip()
+    }
+
     frame.xTicks.forEach((tick, index) => {
       const ratio = (tick.getTime() - frame.domainStart) / Math.max(1, frame.domainEnd - frame.domainStart)
-      const x = frame.margin.left + Math.max(0, Math.min(1, ratio)) * labelWidth
+      const x = frame.margin.left + ratio * labelWidth
       const isFirst = index === 0
       const isLast = index === frame.xTicks.length - 1
       context.textAlign = frame.centerXAxisTickLabels ? 'center' : isFirst ? 'left' : isLast ? 'right' : 'center'
       context.fillText(frame.formatXTick(tick), x, plotBottom + (frame.showXAxisTopRuleFullWidth ? 9 : 7))
     })
+
+    if (frame.clipXAxisLabelsToPlot) {
+      context.restore()
+    }
   }
 
   context.restore()

--- a/src/types/PredictionChartTypes.ts
+++ b/src/types/PredictionChartTypes.ts
@@ -47,6 +47,8 @@ export interface PredictionChartProps {
   xAxisTickFontSize?: number
   yAxisTickFontSize?: number
   centerXAxisTickLabels?: boolean
+  clipXAxisLabelsToPlot?: boolean
+  xAxisLabelsRightClipRatio?: number
   xAxisLabelsRightInset?: number
   alignYAxisLabelsToChartEdge?: boolean
   fadeYAxisEdges?: boolean

--- a/tests/unit/eventLiveSeriesChartUtils.test.ts
+++ b/tests/unit/eventLiveSeriesChartUtils.test.ts
@@ -213,6 +213,26 @@ describe('event live series chart utils', () => {
     expect(renderedEndX).toBeCloseTo(plotWidth - rightInset, 8)
   })
 
+  it('supports positioning the live data endpoint at a requested plot ratio', () => {
+    const startTimestamp = 10_000
+    const endTimestamp = 50_000
+    const chartWidth = 900
+    const marginRight = 52
+    const plotWidth = chartWidth - marginRight
+    const paddedEndTimestamp = resolveLiveChartPaddedDomainEnd({
+      startTimestamp,
+      endTimestamp,
+      chartWidth,
+      marginLeft: 0,
+      marginRight,
+      rightInset: 34,
+      dataEndRatio: 0.6,
+    })
+    const renderedEndX = ((endTimestamp - startTimestamp) / (paddedEndTimestamp - startTimestamp)) * plotWidth
+
+    expect(renderedEndX).toBeCloseTo(plotWidth * 0.6, 8)
+  })
+
   it('builds closed-event history across the event window with canonical endpoints', () => {
     const startTimestamp = Date.parse('2026-08-13T08:00:00.000Z')
     const endTimestamp = Date.parse('2026-08-13T12:00:00.000Z')
@@ -259,6 +279,21 @@ describe('event live series chart utils', () => {
     expect(buildLiveSeriesFallbackData(63_800, chartEndTimestamp)).toEqual([
       {
         date: new Date(chartEndTimestamp - 40_000),
+        [SERIES_KEY]: 63_800,
+      },
+      {
+        date: new Date(chartEndTimestamp),
+        [SERIES_KEY]: 63_800,
+      },
+    ])
+  })
+
+  it('supports a shorter fallback window for compact live charts', () => {
+    const chartEndTimestamp = Date.parse('2026-08-13T15:00:00.000Z')
+
+    expect(buildLiveSeriesFallbackData(63_800, chartEndTimestamp, 20_000)).toEqual([
+      {
+        date: new Date(chartEndTimestamp - 20_000),
         [SERIES_KEY]: 63_800,
       },
       {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Caps the sports legend cursor animation so the hero legend eases between values instead of snapping, and extends the live series chart with a compact layout for featured home carousel slides.

- Adds a featured chart layout with a shorter 8-second window, 4-second tick steps, a tighter y-axis span, and x-axis labels clipped to the plot area, landing the live endpoint at 60% of the plot width.
- Renders the chart on the previous carousel slide so the series is pre-warmed before the slide becomes active.
- Hides the countdown watermark logo in the featured layout to reduce clutter.

<sup>Written for commit c16d8fd81026bdc1aef16ab8c0a2237d559a8bcd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

