### PR TITLE
fix: sanitize OpenRouter title header

### DIFF
--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -36,6 +36,11 @@ const OPENROUTER_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504])
 const OPENROUTER_WEB_SEARCH_PARAMETER = 'web_search_options'
 const inFlightOpenRouterModelInfo = new Map<string, Promise<OpenRouterModelInfo[]>>()
 
+function sanitizeOpenRouterTitle(value: string) {
+  const withoutDiacritics = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+  return withoutDiacritics.replace(/[^\x20-\x7e]/g, '').trim()
+}
+
 interface RequestCompletionOptions {
   temperature?: number
   maxTokens?: number
@@ -57,8 +62,9 @@ async function buildOpenRouterHeaders(apiKey: string) {
   }
 
   const siteName = await loadRuntimeThemeSiteName()
-  if (siteName) {
-    headers['X-Title'] = siteName
+  const openRouterTitle = siteName ? sanitizeOpenRouterTitle(siteName) : ''
+  if (openRouterTitle) {
+    headers['X-OpenRouter-Title'] = openRouterTitle
   }
 
   return headers

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -54,7 +54,7 @@ describe('openrouter helpers', () => {
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toBe('Bearer openrouter-key')
     expect(headers['HTTP-Referer']).toBe('https://kuest.test')
-    expect(headers['X-Title']).toBe('Kuest Runtime')
+    expect(headers['X-OpenRouter-Title']).toBe('Kuest Runtime')
   })
 
   it('loads only web-search-capable models and sends runtime site name in models headers', async () => {
@@ -110,7 +110,7 @@ describe('openrouter helpers', () => {
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toBe('Bearer openrouter-key')
     expect(headers['HTTP-Referer']).toBe('https://kuest.test')
-    expect(headers['X-Title']).toBe('Kuest Runtime')
+    expect(headers['X-OpenRouter-Title']).toBe('Kuest Runtime')
   })
 
   it('loads all available models for translation selection', async () => {
@@ -185,5 +185,25 @@ describe('openrouter helpers', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(webSearchModels.map((model) => model.id)).toEqual(['openai/gpt-4o-mini'])
     expect(allModels.map((model) => model.id)).toEqual(['anthropic/claude-sonnet', 'openai/gpt-4o-mini'])
+  })
+
+  it('omits incompatible characters from the runtime site title header', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.loadRuntimeThemeSiteName.mockResolvedValueOnce('测试站点名称')
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const { fetchAllOpenRouterModels } = await import('@/lib/ai/openrouter')
+    await expect(fetchAllOpenRouterModels('openrouter-key')).resolves.toEqual([])
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-OpenRouter-Title']).toBeUndefined()
   })
 })


### PR DESCRIPTION
## Summary

- Sanitize the runtime site name before sending it as an OpenRouter attribution header.
- Use OpenRouter's documented `X-OpenRouter-Title` header.
- Omit the header when the site name contains no valid printable ASCII characters.
- Add regression coverage for non-ASCII site names.

## Root cause

A non-ASCII runtime site name was being passed directly to `fetch` as an HTTP header value. Node rejects that value before making the OpenRouter request, causing `/admin/api/openrouter-models` to return HTTP 500 for any API key.

## Validation

- Full test suite: 355 test files and 1,859 tests passed.
- `next build` passed.
- Targeted lint, formatting, and regression test checks passed.