### PR TITLE
fix: live chart axis idle

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -53,6 +53,7 @@ import {
   SERIES_KEY,
   toCountdownLeftLabel,
 } from '../_utils/eventLiveSeriesChartUtils'
+import { buildContinuousLiveAxis, interpolateLiveChartAxis, type LiveChartAxis } from '../_utils/liveSeriesChartAxis'
 import {
   resolveLiveSeriesAxisPriceDigits,
   resolveLiveSeriesDeltaDisplayDigits,
@@ -64,16 +65,7 @@ import EventLiveSeriesChartOverlay from './EventLiveSeriesChartOverlay'
 import EventLiveSeriesViewSwitch from './EventLiveSeriesViewSwitch'
 import EventSeriesPills from './EventSeriesPills'
 
-interface LiveChartAxis {
-  min: number
-  max: number
-  ticks: number[]
-  step: number
-}
-
 const LIVE_AXIS_RESPONSE_MS = 1_250
-const LIVE_AXIS_EXTRA_PADDING_RATIO = 0.16
-const LIVE_AXIS_PRICE_FOLLOW_RATIO = 0.18
 const LIVE_AXIS_SETTLE_RATIO = 0.000_05
 const LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO = 0.000_15
 const LIVE_AXIS_TARGET_TICK_INTERVALS = 6
@@ -81,62 +73,6 @@ const FEATURED_LIVE_X_AXIS_DATA_END_RATIO = 0.6
 const FEATURED_LIVE_WINDOW_MS = 8 * 1000
 const FEATURED_LIVE_X_AXIS_STEP_MS = 4 * 1000
 const FEATURED_LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO = 0.000_05
-
-function resolveNiceLiveAxisStep(rawStep: number, minimumStep: number) {
-  const magnitude = 10 ** Math.floor(Math.log10(Math.max(rawStep, minimumStep)))
-  const normalized = rawStep / magnitude
-  const multiplier = normalized <= 1.5 ? 1 : normalized <= 3.5 ? 2 : normalized <= 7.5 ? 5 : 10
-  return Math.max(minimumStep, multiplier * magnitude)
-}
-
-function buildLiveAxisTicks(min: number, max: number, step: number, fractionDigits: number) {
-  const firstTick = Math.ceil(min / step) * step
-  const ticks: number[] = []
-
-  for (let value = firstTick; value <= max + step * 1e-6; value += step) {
-    ticks.push(Number(value.toFixed(Math.max(0, fractionDigits))))
-  }
-
-  return ticks
-}
-
-function buildContinuousLiveAxis(
-  values: number[],
-  currentPrice: number | null,
-  fractionDigits: number,
-  targetTickIntervals = LIVE_AXIS_TARGET_TICK_INTERVALS,
-  minimumSpanRatio = LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO,
-): LiveChartAxis {
-  const minimumStep = 1 / 10 ** Math.max(0, Math.min(6, Math.floor(fractionDigits)))
-  const finiteValues = values.filter((value) => Number.isFinite(value))
-  if (!finiteValues.length) {
-    return { min: 0, max: 1, ticks: [0, 1], step: 1 }
-  }
-
-  const visibleMin = Math.min(...finiteValues)
-  const visibleMax = Math.max(...finiteValues)
-  const visibleMidpoint = (visibleMin + visibleMax) / 2
-  const minimumSpan = Math.max(Math.abs(visibleMidpoint) * minimumSpanRatio, minimumStep * 6)
-  const visibleSpan = Math.max(minimumSpan, visibleMax - visibleMin)
-  const resolvedCurrentPrice = currentPrice != null && Number.isFinite(currentPrice) ? currentPrice : visibleMidpoint
-  const followedCenter = visibleMidpoint + (resolvedCurrentPrice - visibleMidpoint) * LIVE_AXIS_PRICE_FOLLOW_RATIO
-  const minimumHalfSpan = visibleSpan * (0.5 + LIVE_AXIS_EXTRA_PADDING_RATIO)
-  const halfSpan = Math.max(
-    minimumHalfSpan,
-    Math.abs(visibleMin - followedCenter) * 1.12,
-    Math.abs(visibleMax - followedCenter) * 1.12,
-  )
-  const min = followedCenter - halfSpan
-  const max = followedCenter + halfSpan
-  const tickStep = resolveNiceLiveAxisStep((max - min) / targetTickIntervals, minimumStep)
-
-  return {
-    min,
-    max,
-    ticks: buildLiveAxisTicks(min, max, tickStep, fractionDigits),
-    step: tickStep,
-  }
-}
 
 function useStableLiveChartAxis(candidate: LiveChartAxis, scopeKey: string) {
   const [state, setState] = useState<{ scopeKey: string; axis: LiveChartAxis }>(() => ({
@@ -148,7 +84,7 @@ function useStableLiveChartAxis(candidate: LiveChartAxis, scopeKey: string) {
   const animationFrameRef = useRef<number | null>(null)
   const lastFrameTimestampRef = useRef<number | null>(null)
   const displayedAxis = state.scopeKey === scopeKey ? state.axis : candidate
-  const candidateKey = `${candidate.min}:${candidate.max}:${candidate.step}`
+  const candidateKey = `${candidate.min}:${candidate.max}:${candidate.step}:${candidate.fractionDigits}:${candidate.tickIntervals}`
 
   const startAxisAnimation = useCallback(
     function startAxisAnimation() {
@@ -163,12 +99,7 @@ function useStableLiveChartAxis(candidate: LiveChartAxis, scopeKey: string) {
         const elapsedMs = Math.min(64, Math.max(0, timestamp - previousTimestamp))
         lastFrameTimestampRef.current = timestamp
         const progress = 1 - Math.exp(-elapsedMs / LIVE_AXIS_RESPONSE_MS)
-        const nextAxis = {
-          min: current.min + (target.min - current.min) * progress,
-          max: current.max + (target.max - current.max) * progress,
-          ticks: target.ticks,
-          step: target.step,
-        }
+        const nextAxis = interpolateLiveChartAxis(current, target, progress)
         const targetSpan = Math.max(Number.EPSILON, target.max - target.min)
         const remainingDistance = Math.max(Math.abs(nextAxis.min - target.min), Math.abs(nextAxis.max - target.max))
 
@@ -196,7 +127,9 @@ function useStableLiveChartAxis(candidate: LiveChartAxis, scopeKey: string) {
       target.scopeKey === scopeKey &&
       target.axis.min === candidate.min &&
       target.axis.max === candidate.max &&
-      target.axis.step === candidate.step
+      target.axis.step === candidate.step &&
+      target.axis.fractionDigits === candidate.fractionDigits &&
+      target.axis.tickIntervals === candidate.tickIntervals
     ) {
       return undefined
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesChartAxis.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesChartAxis.ts
@@ -1,0 +1,107 @@
+export interface LiveChartAxis {
+  min: number
+  max: number
+  ticks: number[]
+  step: number
+  fractionDigits: number
+  tickIntervals: number
+}
+
+const LIVE_AXIS_EXTRA_PADDING_RATIO = 0.16
+const LIVE_AXIS_PRICE_FOLLOW_RATIO = 0.18
+
+function resolveNiceLiveAxisStep(rawStep: number, minimumStep: number) {
+  const magnitude = 10 ** Math.floor(Math.log10(Math.max(rawStep, minimumStep)))
+  const normalized = rawStep / magnitude
+  const multiplier = normalized <= 1.5 ? 1 : normalized <= 3.5 ? 2 : normalized <= 7.5 ? 5 : 10
+  return Math.max(minimumStep, multiplier * magnitude)
+}
+
+function buildLiveAxisTicks(min: number, max: number, step: number, fractionDigits: number) {
+  const firstTick = Math.ceil(min / step) * step
+  const ticks: number[] = []
+
+  for (let value = firstTick; value <= max + step * 1e-6; value += step) {
+    ticks.push(Number(value.toFixed(Math.max(0, fractionDigits))))
+  }
+
+  return ticks
+}
+
+function buildTicksForBounds(min: number, max: number, fractionDigits: number, tickIntervals: number) {
+  const minimumStep = 1 / 10 ** Math.max(0, Math.min(6, Math.floor(fractionDigits)))
+  const step = resolveNiceLiveAxisStep((max - min) / Math.max(1, tickIntervals), minimumStep)
+
+  return {
+    step,
+    ticks: buildLiveAxisTicks(min, max, step, fractionDigits),
+  }
+}
+
+export function buildContinuousLiveAxis(
+  values: number[],
+  currentPrice: number | null,
+  fractionDigits: number,
+  targetTickIntervals: number,
+  minimumSpanRatio: number,
+): LiveChartAxis {
+  const resolvedFractionDigits = Math.max(0, Math.floor(fractionDigits))
+  const resolvedTickIntervals = Math.max(1, Math.floor(targetTickIntervals))
+  const minimumStep = 1 / 10 ** Math.min(6, resolvedFractionDigits)
+  const finiteValues = values.filter((value) => Number.isFinite(value))
+
+  if (!finiteValues.length) {
+    return {
+      min: 0,
+      max: 1,
+      ticks: [0, 1],
+      step: 1,
+      fractionDigits: resolvedFractionDigits,
+      tickIntervals: resolvedTickIntervals,
+    }
+  }
+
+  const visibleMin = Math.min(...finiteValues)
+  const visibleMax = Math.max(...finiteValues)
+  const visibleMidpoint = (visibleMin + visibleMax) / 2
+  const minimumSpan = Math.max(Math.abs(visibleMidpoint) * minimumSpanRatio, minimumStep * 6)
+  const visibleSpan = Math.max(minimumSpan, visibleMax - visibleMin)
+  const resolvedCurrentPrice = currentPrice != null && Number.isFinite(currentPrice) ? currentPrice : visibleMidpoint
+  const followedCenter = visibleMidpoint + (resolvedCurrentPrice - visibleMidpoint) * LIVE_AXIS_PRICE_FOLLOW_RATIO
+  const minimumHalfSpan = visibleSpan * (0.5 + LIVE_AXIS_EXTRA_PADDING_RATIO)
+  const halfSpan = Math.max(
+    minimumHalfSpan,
+    Math.abs(visibleMin - followedCenter) * 1.12,
+    Math.abs(visibleMax - followedCenter) * 1.12,
+  )
+  const min = followedCenter - halfSpan
+  const max = followedCenter + halfSpan
+  const { step, ticks } = buildTicksForBounds(min, max, resolvedFractionDigits, resolvedTickIntervals)
+
+  return {
+    min,
+    max,
+    ticks,
+    step,
+    fractionDigits: resolvedFractionDigits,
+    tickIntervals: resolvedTickIntervals,
+  }
+}
+
+export function interpolateLiveChartAxis(current: LiveChartAxis, target: LiveChartAxis, progress: number) {
+  const resolvedProgress = Math.max(0, Math.min(1, progress))
+  const min = current.min + (target.min - current.min) * resolvedProgress
+  const max = current.max + (target.max - current.max) * resolvedProgress
+  // The bounds animate, so the ticks must be regenerated for those same bounds.
+  // Reusing target.ticks here makes a newly narrow scale render its grid lines
+  // clustered inside the still-wide scale during the transition.
+  const { step, ticks } = buildTicksForBounds(min, max, target.fractionDigits, target.tickIntervals)
+
+  return {
+    ...target,
+    min,
+    max,
+    step,
+    ticks,
+  }
+}

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -36,6 +36,11 @@ const OPENROUTER_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504])
 const OPENROUTER_WEB_SEARCH_PARAMETER = 'web_search_options'
 const inFlightOpenRouterModelInfo = new Map<string, Promise<OpenRouterModelInfo[]>>()
 
+function sanitizeOpenRouterTitle(value: string) {
+  const withoutDiacritics = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
+  return withoutDiacritics.replace(/[^\x20-\x7e]/g, '').trim()
+}
+
 interface RequestCompletionOptions {
   temperature?: number
   maxTokens?: number
@@ -57,8 +62,9 @@ async function buildOpenRouterHeaders(apiKey: string) {
   }
 
   const siteName = await loadRuntimeThemeSiteName()
-  if (siteName) {
-    headers['X-Title'] = siteName
+  const openRouterTitle = siteName ? sanitizeOpenRouterTitle(siteName) : ''
+  if (openRouterTitle) {
+    headers['X-OpenRouter-Title'] = openRouterTitle
   }
 
   return headers

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -34,11 +34,12 @@ const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions'
 const OPENROUTER_MODELS_API_URL = 'https://openrouter.ai/api/v1/models'
 const OPENROUTER_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504])
 const OPENROUTER_WEB_SEARCH_PARAMETER = 'web_search_options'
+const OPENROUTER_TITLE_FALLBACK = 'Prediction Market'
 const inFlightOpenRouterModelInfo = new Map<string, Promise<OpenRouterModelInfo[]>>()
 
 function sanitizeOpenRouterTitle(value: string) {
   const withoutDiacritics = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
-  return withoutDiacritics.replace(/[^\x20-\x7e]/g, '').trim()
+  return withoutDiacritics.replace(/[^\x20-\x7e]/g, '').trim() || OPENROUTER_TITLE_FALLBACK
 }
 
 interface RequestCompletionOptions {

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -34,12 +34,11 @@ const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions'
 const OPENROUTER_MODELS_API_URL = 'https://openrouter.ai/api/v1/models'
 const OPENROUTER_RETRYABLE_STATUS = new Set([408, 429, 500, 502, 503, 504])
 const OPENROUTER_WEB_SEARCH_PARAMETER = 'web_search_options'
-const OPENROUTER_TITLE_FALLBACK = 'Prediction Market'
 const inFlightOpenRouterModelInfo = new Map<string, Promise<OpenRouterModelInfo[]>>()
 
 function sanitizeOpenRouterTitle(value: string) {
   const withoutDiacritics = value.normalize('NFKD').replace(/[\u0300-\u036f]/g, '')
-  return withoutDiacritics.replace(/[^\x20-\x7e]/g, '').trim() || OPENROUTER_TITLE_FALLBACK
+  return withoutDiacritics.replace(/[^\x20-\x7e]/g, '').trim()
 }
 
 interface RequestCompletionOptions {

--- a/tests/unit/liveSeriesChartAxis.test.ts
+++ b/tests/unit/liveSeriesChartAxis.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildContinuousLiveAxis,
+  interpolateLiveChartAxis,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesChartAxis'
+
+describe('live series chart axis', () => {
+  it('keeps the candidate ticks inside the candidate bounds', () => {
+    const axis = buildContinuousLiveAxis([100, 110], 110, 2, 4, 0.00005)
+
+    expect(axis.ticks.length).toBeGreaterThan(0)
+    expect(axis.ticks.every((tick) => tick >= axis.min && tick <= axis.max)).toBe(true)
+  })
+
+  it('keeps ticks aligned while the axis bounds animate', () => {
+    const current = buildContinuousLiveAxis([90, 110], 110, 2, 4, 0.00005)
+    const target = buildContinuousLiveAxis([100, 100], 100, 2, 4, 0.00005)
+    const interpolated = interpolateLiveChartAxis(current, target, 0.1)
+
+    expect(interpolated.ticks.every((tick) => tick >= interpolated.min && tick <= interpolated.max)).toBe(true)
+    expect(interpolated.ticks).not.toEqual(target.ticks)
+  })
+})

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -54,7 +54,7 @@ describe('openrouter helpers', () => {
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toBe('Bearer openrouter-key')
     expect(headers['HTTP-Referer']).toBe('https://kuest.test')
-    expect(headers['X-Title']).toBe('Kuest Runtime')
+    expect(headers['X-OpenRouter-Title']).toBe('Kuest Runtime')
   })
 
   it('loads only web-search-capable models and sends runtime site name in models headers', async () => {
@@ -110,7 +110,7 @@ describe('openrouter helpers', () => {
     const headers = init.headers as Record<string, string>
     expect(headers.Authorization).toBe('Bearer openrouter-key')
     expect(headers['HTTP-Referer']).toBe('https://kuest.test')
-    expect(headers['X-Title']).toBe('Kuest Runtime')
+    expect(headers['X-OpenRouter-Title']).toBe('Kuest Runtime')
   })
 
   it('loads all available models for translation selection', async () => {
@@ -185,5 +185,25 @@ describe('openrouter helpers', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(webSearchModels.map((model) => model.id)).toEqual(['openai/gpt-4o-mini'])
     expect(allModels.map((model) => model.id)).toEqual(['anthropic/claude-sonnet', 'openai/gpt-4o-mini'])
+  })
+
+  it('omits incompatible characters from the runtime site title header', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.loadRuntimeThemeSiteName.mockResolvedValueOnce('测试站点名称')
+
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    )
+
+    const { fetchAllOpenRouterModels } = await import('@/lib/ai/openrouter')
+    await expect(fetchAllOpenRouterModels('openrouter-key')).resolves.toEqual([])
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+    const headers = init.headers as Record<string, string>
+    expect(headers['X-OpenRouter-Title']).toBeUndefined()
   })
 })

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -187,7 +187,7 @@ describe('openrouter helpers', () => {
     expect(allModels.map((model) => model.id)).toEqual(['anthropic/claude-sonnet', 'openai/gpt-4o-mini'])
   })
 
-  it('omits incompatible characters from the runtime site title header', async () => {
+  it('uses an ASCII fallback when the runtime site title has no compatible characters', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     mocks.loadRuntimeThemeSiteName.mockResolvedValueOnce('测试站点名称')
@@ -204,6 +204,6 @@ describe('openrouter helpers', () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const headers = init.headers as Record<string, string>
-    expect(headers['X-OpenRouter-Title']).toBeUndefined()
+    expect(headers['X-OpenRouter-Title']).toBe('Prediction Market')
   })
 })

--- a/tests/unit/openrouter.test.ts
+++ b/tests/unit/openrouter.test.ts
@@ -187,7 +187,7 @@ describe('openrouter helpers', () => {
     expect(allModels.map((model) => model.id)).toEqual(['anthropic/claude-sonnet', 'openai/gpt-4o-mini'])
   })
 
-  it('uses an ASCII fallback when the runtime site title has no compatible characters', async () => {
+  it('omits incompatible characters from the runtime site title header', async () => {
     const fetchMock = vi.fn()
     vi.stubGlobal('fetch', fetchMock)
     mocks.loadRuntimeThemeSiteName.mockResolvedValueOnce('测试站点名称')
@@ -204,6 +204,6 @@ describe('openrouter helpers', () => {
 
     const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
     const headers = init.headers as Record<string, string>
-    expect(headers['X-OpenRouter-Title']).toBe('Prediction Market')
+    expect(headers['X-OpenRouter-Title']).toBeUndefined()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the live chart so grid ticks stay inside the chart bounds while the axis settles after idle; the OpenRouter header changes from this branch were reverted and no longer ship.

**Changes**

- Regenerates chart ticks from the animated bounds during idle recovery instead of reusing the target ticks.
- Extracts live axis build and interpolation helpers into `liveSeriesChartAxis.ts` with unit tests.

<sup>Written for commit f579ec5de0d755b7bc1fc892e3be5402a54c3e08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

