### PR TITLE
fix: 2fa and hydration regressions

### DIFF
--- a/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils.ts
+++ b/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils.ts
@@ -54,6 +54,18 @@ export function readApiError(payload: unknown): string | null {
   return null
 }
 
+export function resolveCustomSportsSlugMode({
+  explicitlyCustom,
+  isKnownSlug,
+  normalizedSlug,
+}: {
+  explicitlyCustom: boolean
+  isKnownSlug: boolean
+  normalizedSlug: string
+}) {
+  return explicitlyCustom || Boolean(normalizedSlug && !isKnownSlug)
+}
+
 export function formatEventScheduleLabel(value: Date | null) {
   if (!value || Number.isNaN(value.getTime())) {
     return ''

--- a/src/app/[locale]/admin/events/calendar/_components/useAdminCreateEventForm.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/useAdminCreateEventForm.tsx
@@ -142,6 +142,7 @@ import {
   readApiError,
   readResponseBody,
   readResponseErrorMessage,
+  resolveCustomSportsSlugMode,
   resolveStoredAssetFile,
   shortenAddress,
   shouldRetryFinalizeRequest,
@@ -483,20 +484,30 @@ export function useAdminCreateEventForm({
     () => availableLeagueOptions.some((option) => option.value === normalizedLeagueSlug),
     [availableLeagueOptions, normalizedLeagueSlug],
   )
+  const usesCustomSportSlug = resolveCustomSportsSlugMode({
+    explicitlyCustom: isCustomSportSlug,
+    isKnownSlug: isKnownSportSlug,
+    normalizedSlug: normalizedSportSlug,
+  })
+  const usesCustomLeagueSlug = resolveCustomSportsSlugMode({
+    explicitlyCustom: isCustomLeagueSlug,
+    isKnownSlug: isKnownLeagueSlug,
+    normalizedSlug: normalizedLeagueSlug,
+  })
   const sportSlugSelectValue = useMemo(() => {
-    if (isCustomSportSlug) {
+    if (usesCustomSportSlug) {
       return CUSTOM_SPORTS_SLUG_SELECT_VALUE
     }
 
     return isKnownSportSlug ? normalizedSportSlug : undefined
-  }, [isCustomSportSlug, isKnownSportSlug, normalizedSportSlug])
+  }, [isKnownSportSlug, normalizedSportSlug, usesCustomSportSlug])
   const leagueSlugSelectValue = useMemo(() => {
-    if (isCustomLeagueSlug) {
+    if (usesCustomLeagueSlug) {
       return CUSTOM_SPORTS_SLUG_SELECT_VALUE
     }
 
     return isKnownLeagueSlug ? normalizedLeagueSlug : undefined
-  }, [isCustomLeagueSlug, isKnownLeagueSlug, normalizedLeagueSlug])
+  }, [isKnownLeagueSlug, normalizedLeagueSlug, usesCustomLeagueSlug])
   const selectedCreatorAddress = useMemo(() => {
     const candidate = automaticWalletAddress.trim() || eoaAddress || ''
     if (!candidate || !isAddress(candidate)) {
@@ -4231,8 +4242,8 @@ export function useAdminCreateEventForm({
     setIsBinaryOutcomesEditable,
     areMultiOutcomesEditable,
     setAreMultiOutcomesEditable,
-    isCustomSportSlug,
-    isCustomLeagueSlug,
+    isCustomSportSlug: usesCustomSportSlug,
+    isCustomLeagueSlug: usesCustomLeagueSlug,
     eventEndDateInputRef,
     sportsStartTimeInputRef,
     eventImagePreviewUrl,

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingCampaigns.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingCampaigns.tsx
@@ -49,6 +49,8 @@ import {
 import { cn } from '@/lib/utils'
 import { isUserRejectedRequestError } from '@/lib/wallet'
 
+import { resolveCampaignLookupId } from './market-making-campaign-lookup'
+
 export interface MarketMakingCampaignsCopy {
   search: string
   all: string
@@ -756,13 +758,14 @@ export default function MarketMakingCampaigns({ linkedCampaignId, locale, copy }
   const [filter, setFilter] = useState<EscrowCampaignStatusFilter>('all')
   const [search, setSearch] = useState(linkedCampaignId ?? '')
   const [lookupId, setLookupId] = useState<string | null>(null)
+  const [dismissedLinkedCampaignId, setDismissedLinkedCampaignId] = useState<string | null>(null)
   const [selected, setSelected] = useState<MarketMakingCampaignRecord | null>(null)
   const [cancelCampaign, setCancelCampaign] = useState<MarketMakingCampaignRecord | null>(null)
   const [disputeCampaign, setDisputeCampaign] = useState<MarketMakingCampaignRecord | null>(null)
   const [disputeReason, setDisputeReason] = useState<DisputeReason | null>(null)
   const [isMutating, setIsMutating] = useState(false)
   const [now, setNow] = useState(() => Math.floor(Date.now() / 1000))
-  const lookupCampaignId = lookupId ?? linkedCampaignId
+  const lookupCampaignId = resolveCampaignLookupId({ dismissedLinkedCampaignId, linkedCampaignId, lookupId })
   useEffect(() => {
     const interval = window.setInterval(() => setNow(Math.floor(Date.now() / 1000)), 30_000)
     return () => window.clearInterval(interval)
@@ -877,6 +880,7 @@ export default function MarketMakingCampaigns({ linkedCampaignId, locale, copy }
 
   function resetCampaignLookup() {
     handledCampaignId.current = null
+    setDismissedLinkedCampaignId(linkedCampaignId)
     setLookupId(null)
   }
 

--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -34,6 +34,7 @@ import type {
   MarketMakingSourceFilter,
 } from '@/lib/admin-market-making'
 
+import { resolveCampaignsInstanceKey } from '@/app/[locale]/admin/market-making/_components/market-making-campaign-lookup'
 import MarketMakingCampaigns from '@/app/[locale]/admin/market-making/_components/MarketMakingCampaigns'
 import MarketMakingHowItWorks from '@/app/[locale]/admin/market-making/_components/MarketMakingHowItWorks'
 import { Button } from '@/components/ui/button'
@@ -2386,7 +2387,12 @@ export default function MarketMakingDiscovery({
         </TabsContent>
 
         <TabsContent value="campaigns" className="mt-5">
-          <MarketMakingCampaigns linkedCampaignId={linkedCampaignId} locale={locale} copy={campaignsCopy} />
+          <MarketMakingCampaigns
+            key={resolveCampaignsInstanceKey(linkedCampaignId)}
+            linkedCampaignId={linkedCampaignId}
+            locale={locale}
+            copy={campaignsCopy}
+          />
         </TabsContent>
       </Tabs>
 

--- a/src/app/[locale]/admin/market-making/_components/market-making-campaign-lookup.ts
+++ b/src/app/[locale]/admin/market-making/_components/market-making-campaign-lookup.ts
@@ -1,0 +1,15 @@
+export function resolveCampaignLookupId({
+  dismissedLinkedCampaignId,
+  linkedCampaignId,
+  lookupId,
+}: {
+  dismissedLinkedCampaignId: string | null
+  linkedCampaignId: string | null
+  lookupId: string | null
+}) {
+  if (lookupId) {
+    return lookupId
+  }
+
+  return linkedCampaignId === dismissedLinkedCampaignId ? null : linkedCampaignId
+}

--- a/src/app/[locale]/admin/market-making/_components/market-making-campaign-lookup.ts
+++ b/src/app/[locale]/admin/market-making/_components/market-making-campaign-lookup.ts
@@ -13,3 +13,7 @@ export function resolveCampaignLookupId({
 
   return linkedCampaignId === dismissedLinkedCampaignId ? null : linkedCampaignId
 }
+
+export function resolveCampaignsInstanceKey(linkedCampaignId: string | null) {
+  return linkedCampaignId ? `linked-campaign:${linkedCampaignId}` : 'campaigns'
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -327,6 +327,7 @@ export const auth = betterAuth({
       userId: 'user_id',
       accountId: 'account_id',
       providerId: 'provider_id',
+      issuer: 'issuer',
       accessToken: 'access_token',
       refreshToken: 'refresh_token',
       idToken: 'id_token',

--- a/src/lib/db/migrations/2026_08_28_001_account_issuer.sql
+++ b/src/lib/db/migrations/2026_08_28_001_account_issuer.sql
@@ -1,0 +1,12 @@
+ALTER TABLE accounts
+  ADD COLUMN issuer TEXT;
+
+UPDATE accounts
+SET issuer = 'local:' || provider_id
+WHERE issuer IS NULL;
+
+ALTER TABLE accounts
+  ALTER COLUMN issuer SET NOT NULL;
+
+CREATE UNIQUE INDEX idx_accounts_issuer_account_id
+  ON accounts (issuer, account_id);

--- a/src/lib/db/schema/auth/tables.ts
+++ b/src/lib/db/schema/auth/tables.ts
@@ -75,6 +75,7 @@ export const accounts = pgTable('accounts', {
   id: text().primaryKey(),
   account_id: text().notNull(),
   provider_id: text().notNull(),
+  issuer: text().notNull(),
   user_id: text()
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),

--- a/src/lib/siwe-nonce-bridge.ts
+++ b/src/lib/siwe-nonce-bridge.ts
@@ -19,8 +19,8 @@ function pendingIdentifier(nonce: string) {
   return `${PENDING_SIWE_NONCE_PREFIX}${nonce}`
 }
 
-function walletIdentifier(walletAddress: string, chainId: number) {
-  return `siwe:${walletAddress}:${chainId}`
+function siweIdentifier(nonce: string) {
+  return `siwe:${nonce}`
 }
 
 function createExpiry() {
@@ -76,7 +76,7 @@ export async function bindPendingSiweNonce({
 
     await tx.insert(verifications).values({
       id: generateRandomString(VERIFICATION_ID_LENGTH),
-      identifier: walletIdentifier(normalizedWalletAddress, chainId),
+      identifier: siweIdentifier(nonce),
       value: nonce,
       expires_at: pendingNonce.expires_at,
       created_at: now,

--- a/tests/unit/adminCreateEventFormUtils.test.ts
+++ b/tests/unit/adminCreateEventFormUtils.test.ts
@@ -23,6 +23,7 @@ import {
   createInitialForm,
   isBigIntSerializationError,
   mapSignatureFlowErrorForUser,
+  resolveCustomSportsSlugMode,
 } from '@/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils'
 import { buildStepErrors } from '@/app/[locale]/admin/events/calendar/_components/admin-create-event-form-validation'
 import { createInitialAdminSportsForm } from '@/lib/admin-sports-create'
@@ -85,6 +86,27 @@ function buildValidationArgs(
 }
 
 describe('admin create event form utils', () => {
+  describe('resolveCustomSportsSlugMode', () => {
+    it('restores custom mode for a saved slug missing from the catalog', () => {
+      expect(
+        resolveCustomSportsSlugMode({
+          explicitlyCustom: false,
+          isKnownSlug: false,
+          normalizedSlug: 'custom-sport',
+        }),
+      ).toBe(true)
+    })
+
+    it('keeps empty and catalog slugs in select mode', () => {
+      expect(resolveCustomSportsSlugMode({ explicitlyCustom: false, isKnownSlug: false, normalizedSlug: '' })).toBe(
+        false,
+      )
+      expect(
+        resolveCustomSportsSlugMode({ explicitlyCustom: false, isKnownSlug: true, normalizedSlug: 'soccer' }),
+      ).toBe(false)
+    })
+  })
+
   describe('isBigIntSerializationError', () => {
     it('detects provider bigint serialization failures', () => {
       expect(isBigIntSerializationError('Do not know how to serialize a BigInt')).toBe(true)

--- a/tests/unit/authSchemaRelations.test.ts
+++ b/tests/unit/authSchemaRelations.test.ts
@@ -23,4 +23,11 @@ describe('auth schema relations', () => {
     expect(columns.locked_until.name).toBe('locked_until')
     expect(columns.locked_until.notNull).toBe(false)
   })
+
+  it('exposes the Better Auth account issuer field', () => {
+    const columns = getTableColumns(schema.accounts)
+
+    expect(columns.issuer.name).toBe('issuer')
+    expect(columns.issuer.notNull).toBe(true)
+  })
 })

--- a/tests/unit/marketMakingCampaignLookup.test.ts
+++ b/tests/unit/marketMakingCampaignLookup.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
-import { resolveCampaignLookupId } from '@/app/[locale]/admin/market-making/_components/market-making-campaign-lookup'
+import {
+  resolveCampaignLookupId,
+  resolveCampaignsInstanceKey,
+} from '@/app/[locale]/admin/market-making/_components/market-making-campaign-lookup'
 
 describe('market-making campaign lookup', () => {
   it('clears a dismissed campaign deep link', () => {
@@ -31,5 +34,11 @@ describe('market-making campaign lookup', () => {
         lookupId: null,
       }),
     ).toBe('456')
+  })
+
+  it('remounts campaign state when client navigation changes the linked id', () => {
+    expect(resolveCampaignsInstanceKey('123')).toBe('linked-campaign:123')
+    expect(resolveCampaignsInstanceKey('456')).toBe('linked-campaign:456')
+    expect(resolveCampaignsInstanceKey(null)).toBe('campaigns')
   })
 })

--- a/tests/unit/marketMakingCampaignLookup.test.ts
+++ b/tests/unit/marketMakingCampaignLookup.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveCampaignLookupId } from '@/app/[locale]/admin/market-making/_components/market-making-campaign-lookup'
+
+describe('market-making campaign lookup', () => {
+  it('clears a dismissed campaign deep link', () => {
+    expect(
+      resolveCampaignLookupId({
+        dismissedLinkedCampaignId: '123',
+        linkedCampaignId: '123',
+        lookupId: null,
+      }),
+    ).toBeNull()
+  })
+
+  it('allows an explicit lookup after dismissing the deep link', () => {
+    expect(
+      resolveCampaignLookupId({
+        dismissedLinkedCampaignId: '123',
+        linkedCampaignId: '123',
+        lookupId: '456',
+      }),
+    ).toBe('456')
+  })
+
+  it('handles a new campaign deep link', () => {
+    expect(
+      resolveCampaignLookupId({
+        dismissedLinkedCampaignId: '123',
+        linkedCampaignId: '456',
+        lookupId: null,
+      }),
+    ).toBe('456')
+  })
+})

--- a/tests/unit/siweNonceBridge.test.ts
+++ b/tests/unit/siweNonceBridge.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  deleteReturning: vi.fn(),
+  insertValues: vi.fn(),
+  transaction: vi.fn(),
+}))
+
+vi.mock('server-only', () => ({}))
+
+vi.mock('@/lib/drizzle', () => {
+  const tx = {
+    delete: vi.fn(() => ({
+      where: vi.fn(() => ({ returning: mocks.deleteReturning })),
+    })),
+    insert: vi.fn(() => ({ values: mocks.insertValues })),
+  }
+
+  return {
+    db: {
+      transaction: mocks.transaction.mockImplementation(async (callback: (transaction: typeof tx) => unknown) =>
+        callback(tx),
+      ),
+    },
+  }
+})
+
+import { bindPendingSiweNonce } from '@/lib/siwe-nonce-bridge'
+
+describe('pending SIWE nonce bridge', () => {
+  beforeEach(() => {
+    mocks.deleteReturning.mockReset()
+    mocks.insertValues.mockReset()
+    mocks.deleteReturning.mockResolvedValue([{ expires_at: new Date(Date.now() + 60_000) }])
+    mocks.insertValues.mockResolvedValue(undefined)
+  })
+
+  it('moves a pending nonce to the Better Auth verifier key', async () => {
+    await expect(
+      bindPendingSiweNonce({
+        chainId: 137,
+        nonce: 'nonce12345678',
+        walletAddress: '0x1111111111111111111111111111111111111111',
+      }),
+    ).resolves.toEqual({
+      ok: true,
+      walletAddress: '0x1111111111111111111111111111111111111111',
+    })
+
+    expect(mocks.insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identifier: 'siwe:nonce12345678',
+        value: 'nonce12345678',
+      }),
+    )
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes regressions in SIWE 2FA, admin event form hydration, and market-making campaign deep links.

- Adds `issuer` to the `accounts` table so Better Auth 1.7 can persist SIWE accounts.
- Changes the pending SIWE nonce identifier to be nonce-based instead of wallet-address-based.
- Restores custom sport and league slug mode for saved drafts whose slug is missing from the catalog.
- Remembers when a linked campaign deep link is dismissed and remounts campaign state when client navigation changes the linked id.

**Migration**

- Run `src/lib/db/migrations/2026_08_28_001_account_issuer.sql` so the `issuer` column with its unique index is added before deploy.

<sup>Written for commit 5898c8a09a7db0bc6da1514cb3682717cb9248d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

