### PR TITLE
fix: reanchor live chart after idle recovery

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -352,7 +352,7 @@ function EventLiveSeriesChartContent({
     [config.active_window_minutes, realtimeTopic],
   )
 
-  const { data, status } = useLiveSeriesWebSocket({
+  const { data, idleRecovery, idleRecoveryVersion, status } = useLiveSeriesWebSocket({
     topic: realtimeTopic,
     eventType: config.event_type,
     eventEndTimestamp: explicitEndTimestamp,
@@ -704,6 +704,17 @@ function EventLiveSeriesChartContent({
       values.push(axisCurrentPrice)
     }
 
+    const recoverySpan = idleRecovery?.priceSpan
+    if (
+      recoverySpan != null &&
+      recoverySpan > 0 &&
+      typeof axisCurrentPrice === 'number' &&
+      Number.isFinite(axisCurrentPrice)
+    ) {
+      // Keep the resumed price centered while the scale absorbs a large idle-time move.
+      values.push(Math.max(0, axisCurrentPrice - recoverySpan), axisCurrentPrice + recoverySpan)
+    }
+
     return buildContinuousLiveAxis(
       values,
       axisCurrentPrice,
@@ -711,13 +722,16 @@ function EventLiveSeriesChartContent({
       featuredChartLayout ? 4 : LIVE_AXIS_TARGET_TICK_INTERVALS,
       featuredChartLayout ? FEATURED_LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO : LIVE_AXIS_MINIMUM_PRICE_SPAN_RATIO,
     )
-  }, [axisCurrentPrice, axisPriceDisplayDigits, dataSource, featuredChartLayout, renderData])
+  }, [axisCurrentPrice, axisPriceDisplayDigits, dataSource, featuredChartLayout, idleRecovery, renderData])
   const axisInitializationPhase =
     data.length > 0 ? 'realtime-ready' : dataSource.length > 0 ? 'reference-ready' : 'empty'
   const chartScopeKey = preserveSeriesContinuity
     ? `${config.series_slug}:${config.topic}:${config.event_type}:${subscriptionSymbol}`
     : `${event.id}:${realtimeTopic}:${subscriptionSymbol}`
-  const axisValues = useStableLiveChartAxis(candidateAxisValues, `${chartScopeKey}:${axisInitializationPhase}`)
+  const axisValues = useStableLiveChartAxis(
+    candidateAxisValues,
+    `${chartScopeKey}:${axisInitializationPhase}:${idleRecoveryVersion}`,
+  )
 
   const currentLineTop = (() => {
     if (currentPrice == null) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -53,7 +53,12 @@ import {
   SERIES_KEY,
   toCountdownLeftLabel,
 } from '../_utils/eventLiveSeriesChartUtils'
-import { buildContinuousLiveAxis, interpolateLiveChartAxis, type LiveChartAxis } from '../_utils/liveSeriesChartAxis'
+import {
+  buildContinuousLiveAxis,
+  buildLiveChartRecoveryValues,
+  interpolateLiveChartAxis,
+  type LiveChartAxis,
+} from '../_utils/liveSeriesChartAxis'
 import {
   resolveLiveSeriesAxisPriceDigits,
   resolveLiveSeriesDeltaDisplayDigits,
@@ -704,15 +709,10 @@ function EventLiveSeriesChartContent({
       values.push(axisCurrentPrice)
     }
 
-    const recoverySpan = idleRecovery?.priceSpan
-    if (
-      recoverySpan != null &&
-      recoverySpan > 0 &&
-      typeof axisCurrentPrice === 'number' &&
-      Number.isFinite(axisCurrentPrice)
-    ) {
+    const recoveryValues = buildLiveChartRecoveryValues(axisCurrentPrice, idleRecovery?.priceSpan ?? null)
+    if (recoveryValues.length > 0) {
       // Keep the resumed price centered while the scale absorbs a large idle-time move.
-      values.push(Math.max(0, axisCurrentPrice - recoverySpan), axisCurrentPrice + recoverySpan)
+      values.push(...recoveryValues)
     }
 
     return buildContinuousLiveAxis(

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -12,14 +12,18 @@ import {
 
 import {
   appendLivePriceTransition,
+  buildLiveSeriesIdleResetData,
   extractLivePriceUpdates,
   isSnapshotMessage,
   keepWithinLiveWindow,
+  LIVE_IDLE_RECOVERY_DISPLAY_MS,
   LIVE_DATA_RETENTION_MS,
   MAX_POINTS,
   normalizeLiveChartPrice,
+  resolveLiveSeriesIdleRecoverySpan,
   resolveLivePriceTransitionDuration,
   SERIES_KEY,
+  shouldResetLiveSeriesAfterIdle,
   writePersistedLivePrice,
 } from '../_utils/eventLiveSeriesChartUtils'
 
@@ -29,6 +33,11 @@ interface UseLiveSeriesWebSocketOptions {
   eventEndTimestamp: number | null
   subscriptionSymbol: string
   isLiveView: boolean
+}
+
+interface LiveSeriesIdleRecovery {
+  version: number
+  priceSpan: number | null
 }
 
 export function useLiveSeriesWebSocket({
@@ -42,6 +51,8 @@ export function useLiveSeriesWebSocket({
   const wsUrl = wsLiveDataUrl
   const eventEndTimestampRef = useRef(eventEndTimestamp)
   const [data, setData] = useState<DataPoint[]>([])
+  const [idleRecovery, setIdleRecovery] = useState<LiveSeriesIdleRecovery | null>(null)
+  const [idleRecoveryVersion, setIdleRecoveryVersion] = useState(0)
   const [status, setStatus] = useState<'connecting' | 'live' | 'offline'>(() => (wsUrl ? 'connecting' : 'offline'))
 
   useEffect(
@@ -66,6 +77,38 @@ export function useLiveSeriesWebSocket({
       let isActive = true
       let ws: WebSocket | null = null
       let previousPriceMessageTimestamp: number | null = null
+      let lastMessageArrivalTimestamp: number | null = null
+      let latestKnownPrice: number | null = null
+      let hiddenAtTimestamp: number | null = document.hidden ? Date.now() : null
+      let idleRecoveryRequested = false
+      let idleRecoveryUntilTimestamp: number | null = null
+      let idleRecoveryVersion = 0
+      let idleRecoveryClearTimeout: number | null = null
+
+      function clearIdleRecoveryTimer() {
+        if (idleRecoveryClearTimeout == null) {
+          return
+        }
+
+        window.clearTimeout(idleRecoveryClearTimeout)
+        idleRecoveryClearTimeout = null
+      }
+
+      function startIdleRecovery(currentPrice: number, recoveryTimestamp: number) {
+        idleRecoveryVersion += 1
+        idleRecoveryUntilTimestamp = recoveryTimestamp + LIVE_IDLE_RECOVERY_DISPLAY_MS
+        setIdleRecoveryVersion(idleRecoveryVersion)
+        setIdleRecovery({
+          version: idleRecoveryVersion,
+          priceSpan: resolveLiveSeriesIdleRecoverySpan(latestKnownPrice, currentPrice),
+        })
+        clearIdleRecoveryTimer()
+        idleRecoveryClearTimeout = window.setTimeout(() => {
+          idleRecoveryClearTimeout = null
+          idleRecoveryUntilTimestamp = null
+          setIdleRecovery(null)
+        }, LIVE_IDLE_RECOVERY_DISPLAY_MS)
+      }
 
       function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
         const filters = JSON.stringify({
@@ -132,6 +175,29 @@ export function useLiveSeriesWebSocket({
         }
         heartbeatController?.markActivity(socket, arrivalTimestamp)
 
+        const latest = wsUpdatesForRender.at(-1)
+        if (!latest) {
+          return
+        }
+
+        const idleGapDetected = shouldResetLiveSeriesAfterIdle(
+          lastMessageArrivalTimestamp,
+          arrivalTimestamp,
+          LIVE_DATA_RETENTION_MS,
+        )
+        const idleRecoveryIsActive = idleRecoveryUntilTimestamp != null && arrivalTimestamp < idleRecoveryUntilTimestamp
+        const shouldReanchorAfterIdle = idleRecoveryRequested || idleGapDetected || idleRecoveryIsActive
+
+        if (idleRecoveryRequested || idleGapDetected) {
+          if (!idleRecoveryIsActive) {
+            startIdleRecovery(latest.price, arrivalTimestamp)
+          }
+          idleRecoveryRequested = false
+        }
+
+        lastMessageArrivalTimestamp = arrivalTimestamp
+        latestKnownPrice = latest.price
+
         const cadenceTransitionDurationMs = resolveLivePriceTransitionDuration(
           previousPriceMessageTimestamp,
           arrivalTimestamp,
@@ -145,13 +211,17 @@ export function useLiveSeriesWebSocket({
         previousPriceMessageTimestamp = arrivalTimestamp
 
         setStatus('live')
-        const latest = wsUpdatesForRender.at(-1)
-        if (latest) {
-          writePersistedLivePrice(topic, subscriptionSymbol, latest.price, latest.timestamp)
-        }
+        writePersistedLivePrice(topic, subscriptionSymbol, latest.price, latest.timestamp)
 
         setData((prev) => {
           const cutoff = arrivalTimestamp - LIVE_DATA_RETENTION_MS
+
+          if (shouldReanchorAfterIdle) {
+            // A resumed connection may deliver a large historical snapshot or a
+            // backlog of updates. Keep only the current value and let the next
+            // live update continue from this fresh 40-second window.
+            return buildLiveSeriesIdleResetData(latest.price, transitionStartTimestamp)
+          }
 
           if (messageIsSnapshot) {
             let lastSnapshotTimestamp: number | null = null
@@ -212,7 +282,15 @@ export function useLiveSeriesWebSocket({
       }
 
       function handleVisibilityChange() {
-        if (!document.hidden) {
+        const visibilityTimestamp = Date.now()
+        if (document.hidden) {
+          hiddenAtTimestamp ??= visibilityTimestamp
+        } else {
+          const hiddenDuration = hiddenAtTimestamp == null ? 0 : visibilityTimestamp - hiddenAtTimestamp
+          if (hiddenDuration >= LIVE_DATA_RETENTION_MS) {
+            idleRecoveryRequested = true
+          }
+          hiddenAtTimestamp = null
           previousPriceMessageTimestamp = null
           setStatus('connecting')
         }
@@ -275,6 +353,8 @@ export function useLiveSeriesWebSocket({
       return function cleanupLiveSeriesWebSocket() {
         isActive = false
         setStatus('offline')
+        clearIdleRecoveryTimer()
+        idleRecoveryUntilTimestamp = null
         heartbeatController.clear()
         clearReconnect()
         document.removeEventListener('visibilitychange', handleVisibilityChange)
@@ -294,5 +374,5 @@ export function useLiveSeriesWebSocket({
     [eventType, topic, isLiveView, wsUrl, subscriptionSymbol],
   )
 
-  return { data, status }
+  return { data, idleRecovery, idleRecoveryVersion, status }
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -355,6 +355,8 @@ export function useLiveSeriesWebSocket({
         setStatus('offline')
         clearIdleRecoveryTimer()
         idleRecoveryUntilTimestamp = null
+        setIdleRecovery(null)
+        setIdleRecoveryVersion(0)
         heartbeatController.clear()
         clearReconnect()
         document.removeEventListener('visibilitychange', handleVisibilityChange)

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -9,6 +9,7 @@ export const SERIES_KEY = 'live_price'
 export const LIVE_WINDOW_MS = 40 * 1000
 const LIVE_HISTORY_BUFFER_MS = 8 * 1000
 export const LIVE_DATA_RETENTION_MS = LIVE_WINDOW_MS + LIVE_HISTORY_BUFFER_MS
+export const LIVE_IDLE_RECOVERY_DISPLAY_MS = 1_250
 export const LIVE_CLOCK_FRAME_MS = 1000 / 30
 export const LIVE_X_AXIS_STEP_MS = 10 * 1000
 export const LIVE_X_AXIS_RIGHT_INSET = 84
@@ -61,6 +62,44 @@ export function buildLiveSeriesFallbackData(
       [SERIES_KEY]: price,
     },
   ] satisfies DataPoint[]
+}
+
+export function buildLiveSeriesIdleResetData(price: number | null, chartEndTimestamp: number) {
+  return buildLiveSeriesFallbackData(price, chartEndTimestamp, LIVE_WINDOW_MS)
+}
+
+export function shouldResetLiveSeriesAfterIdle(
+  previousArrivalTimestamp: number | null,
+  currentArrivalTimestamp: number,
+  thresholdMs = LIVE_DATA_RETENTION_MS,
+) {
+  if (
+    previousArrivalTimestamp == null ||
+    !Number.isFinite(previousArrivalTimestamp) ||
+    !Number.isFinite(currentArrivalTimestamp) ||
+    !Number.isFinite(thresholdMs) ||
+    thresholdMs <= 0
+  ) {
+    return false
+  }
+
+  return currentArrivalTimestamp - previousArrivalTimestamp >= thresholdMs
+}
+
+export function resolveLiveSeriesIdleRecoverySpan(previousPrice: number | null, currentPrice: number | null) {
+  if (
+    previousPrice == null ||
+    currentPrice == null ||
+    !Number.isFinite(previousPrice) ||
+    !Number.isFinite(currentPrice) ||
+    previousPrice <= 0 ||
+    currentPrice <= 0
+  ) {
+    return null
+  }
+
+  const span = Math.abs(currentPrice - previousPrice)
+  return span > 0 ? span : null
 }
 
 export function resolveLiveChartPaddedDomainEnd({

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesChartAxis.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesChartAxis.ts
@@ -38,6 +38,22 @@ function buildTicksForBounds(min: number, max: number, fractionDigits: number, t
   }
 }
 
+export function buildLiveChartRecoveryValues(currentPrice: number | null, recoverySpan: number | null) {
+  if (
+    currentPrice == null ||
+    recoverySpan == null ||
+    !Number.isFinite(currentPrice) ||
+    !Number.isFinite(recoverySpan) ||
+    currentPrice <= 0 ||
+    recoverySpan <= 0
+  ) {
+    return []
+  }
+
+  const boundedSpan = Math.min(recoverySpan, currentPrice)
+  return [currentPrice - boundedSpan, currentPrice + boundedSpan]
+}
+
 export function buildContinuousLiveAxis(
   values: number[],
   currentPrice: number | null,

--- a/tests/unit/liveSeriesChartAxis.test.ts
+++ b/tests/unit/liveSeriesChartAxis.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   buildContinuousLiveAxis,
+  buildLiveChartRecoveryValues,
   interpolateLiveChartAxis,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesChartAxis'
 
@@ -20,5 +21,10 @@ describe('live series chart axis', () => {
 
     expect(interpolated.ticks.every((tick) => tick >= interpolated.min && tick <= interpolated.max)).toBe(true)
     expect(interpolated.ticks).not.toEqual(target.ticks)
+  })
+
+  it('keeps a large downward recovery range symmetric and nonnegative', () => {
+    expect(buildLiveChartRecoveryValues(40, 60)).toEqual([0, 80])
+    expect(buildLiveChartRecoveryValues(100, 20)).toEqual([80, 120])
   })
 })

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useLiveSeriesWebSocket } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket'
 import {
+  LIVE_DATA_RETENTION_MS,
   resolveLivePriceTransitionDuration,
   SERIES_KEY,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils'
@@ -368,6 +369,80 @@ describe('useLiveSeriesWebSocket', () => {
 
     expect(result.current.data).toBe(visibleData)
     expect(result.current.data).toHaveLength(2)
+    hiddenSpy.mockRestore()
+  })
+
+  it('reanchors to the latest price instead of rendering a long-idle snapshot backlog', () => {
+    const { result, socket } = mountHook()
+
+    act(() =>
+      socket.emitMessage({
+        type: 'subscribe',
+        data: [{ symbol: 'BTC', value: 100, timestamp: now - 1_000 }],
+      }),
+    )
+
+    now += LIVE_DATA_RETENTION_MS + 1_000
+    const snapshot = Array.from({ length: 300 }, (_, index) => ({
+      symbol: 'BTC',
+      value: 100 + index / 100,
+      timestamp: now - 30_000 + index * 100,
+    }))
+
+    act(() =>
+      socket.emitMessage({
+        type: 'subscribe',
+        payload: { data: snapshot },
+      }),
+    )
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.data.every((point) => point[SERIES_KEY] === 102.99)).toBe(true)
+    expect(result.current.idleRecoveryVersion).toBe(1)
+    expect(result.current.idleRecovery?.priceSpan).toBeCloseTo(2.99)
+  })
+
+  it('reanchors after a long hidden period even when updates arrived while hidden', () => {
+    let isHidden = false
+    const hiddenSpy = vi.spyOn(document, 'hidden', 'get').mockImplementation(() => isHidden)
+    const { result, socket } = mountHook()
+
+    act(() =>
+      socket.emitMessage({
+        type: 'subscribe',
+        data: [{ symbol: 'BTC', value: 100, timestamp: now - 1_000 }],
+      }),
+    )
+
+    act(() => {
+      isHidden = true
+      document.dispatchEvent(new Event('visibilitychange'))
+      now += LIVE_DATA_RETENTION_MS + 1_000
+      socket.emitMessage({
+        type: 'update',
+        symbol: 'BTC',
+        value: 120,
+        timestamp: now,
+      })
+      isHidden = false
+      document.dispatchEvent(new Event('visibilitychange'))
+    })
+
+    act(() =>
+      socket.emitMessage({
+        type: 'subscribe',
+        payload: {
+          data: [
+            { symbol: 'BTC', value: 150, timestamp: now - 1_000 },
+            { symbol: 'BTC', value: 151, timestamp: now },
+          ],
+        },
+      }),
+    )
+
+    expect(result.current.data).toHaveLength(2)
+    expect(result.current.data.every((point) => point[SERIES_KEY] === 151)).toBe(true)
+    expect(result.current.idleRecoveryVersion).toBe(1)
     hiddenSpy.mockRestore()
   })
 })

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -445,4 +445,46 @@ describe('useLiveSeriesWebSocket', () => {
     expect(result.current.idleRecoveryVersion).toBe(1)
     hiddenSpy.mockRestore()
   })
+
+  it('clears idle recovery state when the websocket effect is recreated', () => {
+    const view = renderHook(
+      ({ subscriptionSymbol }) =>
+        useLiveSeriesWebSocket({
+          topic: 'crypto_prices',
+          eventType: 'price',
+          eventEndTimestamp: null,
+          subscriptionSymbol,
+          isLiveView: true,
+        }),
+      { initialProps: { subscriptionSymbol: 'BTC' } },
+    )
+    const firstSocket = MockWebSocket.instances[0]!
+    act(() => firstSocket.emitOpen())
+
+    act(() =>
+      firstSocket.emitMessage({
+        type: 'subscribe',
+        data: [{ symbol: 'BTC', value: 100, timestamp: now - 1_000 }],
+      }),
+    )
+
+    now += LIVE_DATA_RETENTION_MS + 1_000
+    act(() =>
+      firstSocket.emitMessage({
+        type: 'update',
+        symbol: 'BTC',
+        value: 120,
+        timestamp: now,
+      }),
+    )
+
+    expect(view.result.current.idleRecoveryVersion).toBe(1)
+    expect(view.result.current.idleRecovery).not.toBeNull()
+
+    view.rerender({ subscriptionSymbol: 'ETH' })
+
+    expect(view.result.current.idleRecovery).toBeNull()
+    expect(view.result.current.idleRecoveryVersion).toBe(0)
+    view.unmount()
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the live chart so it reanchors to the latest price after the WebSocket connection resumes from an idle gap, instead of rendering the backlog of stale snapshot points.

**Bug Fixes**
- On idle recovery (message gap or long-hidden tab), the chart resets to a fresh two-point window at the latest price.
- Adds a temporary idle-recovery state that widens the price axis span for 1.25 seconds to absorb the idle-time price move smoothly.
- Tracks an idle-recovery version to invalidate the chart axis cache so the resumed price stays centered.
- Clears idle-recovery state when the websocket effect is recreated so stale state doesn't leak across symbol changes.
- Adds tests covering the message-gap, hidden-tab, and effect-recreation recovery paths.

<sup>Written for commit 7cd3403a8ed49042a2acba2654bdb3a95517907f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

