### PR TITLE
fix: cast translation scheduling priorities to bigint

### DIFF
--- a/src/app/api/sync/translations/route.ts
+++ b/src/app/api/sync/translations/route.ts
@@ -24,6 +24,7 @@ import {
   resolveTranslationSourceFingerprint,
 } from '@/lib/translations/batch'
 import { isNonDefaultLocale, parseEventJobPayload, parseTagJobPayload } from '@/lib/translations/jobs'
+import { buildTranslationLocaleSchedulingExpressions } from '@/lib/translations/scheduling'
 
 export const maxDuration = 60
 
@@ -253,11 +254,10 @@ async function fetchCandidateJobs(nowIso: string, locales: NonDefaultLocale[]): 
   }
 
   const localeExpression = sql<string>`split_part(${jobsTable.dedupe_key}, ':', 2)`
-  const localePriorityExpression = sql<number>`CASE ${localeExpression} ${sql.join(
-    locales.map((locale, index) => sql`WHEN ${locale} THEN ${index}`),
-    sql` `,
-  )} ELSE ${locales.length} END`
-  const localeWeightExpression = sql<number>`${locales.length} - ${localePriorityExpression}`
+  const { localePriorityExpression, localeWeightExpression } = buildTranslationLocaleSchedulingExpressions(
+    localeExpression,
+    locales,
+  )
   const localeRankExpression = sql<number>`row_number() OVER (
     PARTITION BY ${localeExpression}
     ORDER BY ${jobsTable.available_at}, ${jobsTable.updated_at}, ${jobsTable.id}

--- a/src/lib/translations/scheduling.ts
+++ b/src/lib/translations/scheduling.ts
@@ -1,0 +1,18 @@
+import type { SQL } from 'drizzle-orm'
+
+import { sql } from 'drizzle-orm'
+
+import type { NonDefaultLocale } from '@/i18n/locales'
+
+export function buildTranslationLocaleSchedulingExpressions(
+  localeExpression: SQL<string>,
+  locales: NonDefaultLocale[],
+) {
+  const localePriorityExpression = sql<number>`CASE ${localeExpression} ${sql.join(
+    locales.map((locale, index) => sql`WHEN ${locale} THEN CAST(${index} AS bigint)`),
+    sql` `,
+  )} ELSE CAST(${locales.length} AS bigint) END`
+  const localeWeightExpression = sql<number>`CAST(${locales.length} AS bigint) - ${localePriorityExpression}`
+
+  return { localePriorityExpression, localeWeightExpression }
+}

--- a/tests/unit/translationScheduling.test.ts
+++ b/tests/unit/translationScheduling.test.ts
@@ -1,0 +1,17 @@
+import { sql } from 'drizzle-orm'
+import { PgDialect } from 'drizzle-orm/pg-core'
+import { describe, expect, it } from 'vitest'
+
+import { buildTranslationLocaleSchedulingExpressions } from '@/lib/translations/scheduling'
+
+describe('translation locale scheduling', () => {
+  it('casts generated priority values before bigint arithmetic', () => {
+    const localeExpression = sql<string>`split_part(${'event:pt'}, ':', 2)`
+    const { localeWeightExpression } = buildTranslationLocaleSchedulingExpressions(localeExpression, ['pt', 'fr'])
+    const query = new PgDialect().sqlToQuery(localeWeightExpression)
+
+    expect(query.sql).toMatch(/^CAST\(\$1 AS bigint\) - CASE/)
+    expect(query.sql.match(/THEN CAST\(\$\d+ AS bigint\)/g)).toHaveLength(2)
+    expect(query.sql).toMatch(/ELSE CAST\(\$\d+ AS bigint\) END$/)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes translation scheduling priority expressions so priority and weight values are cast to `bigint` before arithmetic, preventing type mismatches in Postgres.

- Extracts the locale priority/weight SQL generation into `buildTranslationLocaleSchedulingExpressions` for reuse and testability.
- Adds a unit test covering the generated SQL for the bigint casts.

<sup>Written for commit baab24b0d7b8d34bdf69101f6f27ca7ea227122a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

