### PR TITLE
fix: polish market making sponsorship dialog

### DIFF
--- a/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
+++ b/src/app/[locale]/admin/market-making/_components/MarketMakingDiscovery.tsx
@@ -2217,6 +2217,7 @@ function CampaignDialog({
                   render={
                     <button
                       type="button"
+                      disabled={usesImportFlow || sponsorSeries || !hasSelectableServiceWindow}
                       className="flex items-center gap-2.5 rounded-xl border p-2.5 text-left transition-colors hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
                     />
                   }
@@ -2252,7 +2253,7 @@ function CampaignDialog({
                     startMonth={hasSelectableServiceWindow ? minimumServiceEndDate : marketEndDate}
                     endMonth={marketEndDate}
                     disabled={
-                      sponsorSeries || !hasSelectableServiceWindow
+                      usesImportFlow || sponsorSeries || !hasSelectableServiceWindow
                         ? true
                         : { before: minimumServiceEndDate, after: marketEndDate }
                     }
@@ -2299,59 +2300,59 @@ function CampaignDialog({
           <aside className="mt-4 flex flex-col gap-3 lg:sticky lg:top-0 lg:col-start-2 lg:row-start-1 lg:mt-0 lg:min-h-0 lg:overflow-y-auto">
             <section className="relative rounded-xl border bg-muted/60 p-3.5 sm:p-4">
               <div className="space-y-3 text-sm">
-                <div className="flex items-start justify-between gap-3 border-b pb-3">
-                  <div className="min-w-0">
+                <div className="flex flex-wrap items-start gap-x-3 gap-y-1.5 border-b pb-3">
+                  <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-1.5">
                       <span className="font-medium">{copy.makerReward}</span>
-                    </div>
-                    <div className="mt-1.5 flex items-center gap-2">
-                      <div className="flex items-center gap-1">
-                        <Label htmlFor="sponsor-premium" className="text-xs text-muted-foreground">
-                          {copy.sponsorPremium}
-                        </Label>
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <button
-                                type="button"
-                                className="text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
-                                aria-label={copy.sponsorPremiumHelp}
-                              />
-                            }
-                          >
-                            <CircleHelpIcon className="size-3.5" />
-                          </TooltipTrigger>
-                          <TooltipContent className="max-w-72 text-sm">{copy.sponsorPremiumHelp}</TooltipContent>
-                        </Tooltip>
-                      </div>
-                      <div className="relative w-20 shrink-0">
-                        <Input
-                          id="sponsor-premium"
-                          type="number"
-                          min={0}
-                          max={1000}
-                          step={1}
-                          inputMode="numeric"
-                          value={sponsorPremiumPercent}
-                          aria-invalid={!sponsorPremiumValid}
-                          onChange={(event) => {
-                            const value = event.target.value
-                            if (isSponsorPremiumValid(value)) {
-                              setSponsorPremiumPercent(value)
-                              clearIssuedQuote()
-                            }
-                          }}
-                          className="h-8 pr-6 text-right text-xs"
-                        />
-                        <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-muted-foreground">
-                          %
-                        </span>
-                      </div>
                     </div>
                   </div>
                   <span className="shrink-0 font-medium">
                     {breakdown ? formatUsdcString(breakdown.marketMakerReward, locale) : '—'}
                   </span>
+                  <div className="flex w-full items-center justify-between gap-2">
+                    <div className="flex items-center gap-1">
+                      <Label htmlFor="sponsor-premium" className="text-xs text-muted-foreground">
+                        {copy.sponsorPremium}
+                      </Label>
+                      <Tooltip>
+                        <TooltipTrigger
+                          render={
+                            <button
+                              type="button"
+                              className="text-muted-foreground transition-colors hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                              aria-label={copy.sponsorPremiumHelp}
+                            />
+                          }
+                        >
+                          <CircleHelpIcon className="size-3.5" />
+                        </TooltipTrigger>
+                        <TooltipContent className="max-w-72 text-sm">{copy.sponsorPremiumHelp}</TooltipContent>
+                      </Tooltip>
+                    </div>
+                    <div className="relative w-20 shrink-0">
+                      <Input
+                        id="sponsor-premium"
+                        type="number"
+                        min={0}
+                        max={1000}
+                        step={1}
+                        inputMode="numeric"
+                        value={sponsorPremiumPercent}
+                        aria-invalid={!sponsorPremiumValid}
+                        onChange={(event) => {
+                          const value = event.target.value
+                          if (isSponsorPremiumValid(value)) {
+                            setSponsorPremiumPercent(value)
+                            clearIssuedQuote()
+                          }
+                        }}
+                        className="h-8 pr-6 text-right text-xs"
+                      />
+                      <span className="pointer-events-none absolute inset-y-0 right-2 flex items-center text-xs text-muted-foreground">
+                        %
+                      </span>
+                    </div>
+                  </div>
                 </div>
 
                 {!isConnected ? (

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -311,7 +311,7 @@ export default function HeaderDropdownUserMenuAuth() {
             </DropdownMenuLinkItem>
           )}
 
-          <div className="flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground">
+          <div className="flex items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground">
             <span>{t('Dark Mode')}</span>
             <ThemeSelector />
           </div>

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -1,7 +1,15 @@
 'use client'
 
 import { useDisconnect } from '@reown/appkit/react'
-import { ChevronDownIcon, DownloadIcon, GiftIcon, SettingsIcon, ShieldIcon, TrophyIcon, UnplugIcon } from 'lucide-react'
+import {
+  ChevronDownIcon,
+  DownloadIcon,
+  GiftIcon,
+  SettingsIcon,
+  ShieldKeyholeIcon,
+  TrophyIcon,
+  UnplugIcon,
+} from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import Image from 'next/image'
 import { useEffect, useRef, useState } from 'react'
@@ -298,12 +306,12 @@ export default function HeaderDropdownUserMenuAuth() {
               render={<Link href="/admin" className="flex w-full items-center gap-1.5" />}
               className="py-2 text-sm font-semibold"
             >
-              <ShieldIcon className="size-4 text-current" />
+              <ShieldKeyholeIcon className="size-4 text-current" />
               {t('Admin')}
             </DropdownMenuLinkItem>
           )}
 
-          <div className="flex items-center justify-between gap-2 px-2 py-1 text-sm font-semibold">
+          <div className="flex cursor-pointer items-center justify-between gap-2 rounded-sm px-2 py-1.5 text-sm font-semibold transition-colors hover:bg-accent hover:text-accent-foreground">
             <span>{t('Dark Mode')}</span>
             <ThemeSelector />
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes editing restrictions and layout issues in the market making sponsorship dialog, and polishes the authenticated header menu.

- Disables the service window picker and sponsor premium input when using the import flow or series sponsorship.
- Restructures the maker reward display so the premium input wraps correctly on narrow screens.
- Switches the admin menu icon to a keyhole shield and makes the dark mode toggle respond to hover.

<sup>Written for commit 509925662de74b4d4678a2cbba854e2c299509f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

