### PR TITLE
fix: polymarket arbitrage toggle

### DIFF
--- a/src/app/api/affiliate-settings/route.ts
+++ b/src/app/api/affiliate-settings/route.ts
@@ -1,3 +1,4 @@
+import { io } from 'next/cache'
 import { unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
 
@@ -5,7 +6,6 @@ import { bpsToPercent, getAffiliateFeeSettings, getAffiliateFeeSettingsUpdatedAt
 import { MUTABLE_API_CACHE_CONTROL } from '@/lib/api-cache'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { SettingsRepository } from '@/lib/db/queries/settings'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 interface AffiliateSettingsResponse {
   builderTakerSharePercent: number
@@ -16,7 +16,7 @@ interface AffiliateSettingsResponse {
 
 export async function GET() {
   try {
-    await deferPublicShellPrerenderIfNeeded()
+    await io()
 
     const { data: settings, error } = await SettingsRepository.getSettings()
 

--- a/src/app/api/arbitrage/config/route.ts
+++ b/src/app/api/arbitrage/config/route.ts
@@ -1,12 +1,12 @@
+import { io } from 'next/cache'
 import { NextResponse } from 'next/server'
 
 import { MUTABLE_API_CACHE_CONTROL } from '@/lib/api-cache'
 import { isArbitrageEnabled, isArbitrageMultiWalletEnabled } from '@/lib/arbitrage-settings'
 import { SettingsRepository } from '@/lib/db/queries/settings'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
-  await deferPublicShellPrerenderIfNeeded()
+  await io()
   const { data: settings } = await SettingsRepository.getSettings()
 
   return NextResponse.json(

--- a/src/app/api/geoblock/route.ts
+++ b/src/app/api/geoblock/route.ts
@@ -1,11 +1,11 @@
+import { io } from 'next/cache'
 import { NextResponse } from 'next/server'
 
 import { MUTABLE_API_CACHE_CONTROL } from '@/lib/api-cache'
 import { loadBlockedCountries } from '@/lib/geoblock-settings'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
-  await deferPublicShellPrerenderIfNeeded()
+  await io()
 
   const blockedCountries = await loadBlockedCountries()
 

--- a/src/app/api/lifi/chains/route.ts
+++ b/src/app/api/lifi/chains/route.ts
@@ -1,10 +1,10 @@
+import { io } from 'next/cache'
 import { NextResponse } from 'next/server'
 
 import { getLiFiServerActions } from '@/lib/lifi'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
-  await deferPublicShellPrerenderIfNeeded()
+  await io()
 
   const lifi = await getLiFiServerActions()
 

--- a/src/app/api/locales/route.ts
+++ b/src/app/api/locales/route.ts
@@ -1,13 +1,13 @@
+import { io } from 'next/cache'
 import { unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
 
 import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { MUTABLE_API_CACHE_CONTROL } from '@/lib/api-cache'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
   try {
-    await deferPublicShellPrerenderIfNeeded()
+    await io()
 
     const locales = await loadEnabledLocales()
     return NextResponse.json({ locales }, { headers: { 'Cache-Control': MUTABLE_API_CACHE_CONTROL } })

--- a/tests/unit/mutableApiCache.test.ts
+++ b/tests/unit/mutableApiCache.test.ts
@@ -3,14 +3,21 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { GET as getAffiliateSettings } from '@/app/api/affiliate-settings/route'
 import { GET as getArbitrageConfig } from '@/app/api/arbitrage/config/route'
 import { GET as getGeoblockSettings } from '@/app/api/geoblock/route'
+import { GET as getLiFiChains } from '@/app/api/lifi/chains/route'
 import { GET as getLocales } from '@/app/api/locales/route'
 import { MUTABLE_API_CACHE_CONTROL } from '@/lib/api-cache'
 
 const mocks = vi.hoisted(() => ({
   deferPrerender: vi.fn().mockResolvedValue(undefined),
+  getLiFiChains: vi.fn().mockResolvedValue([]),
   getSettings: vi.fn().mockResolvedValue({ data: {}, error: null }),
+  io: vi.fn().mockResolvedValue(undefined),
   loadBlockedCountries: vi.fn().mockResolvedValue([]),
   loadEnabledLocales: vi.fn().mockResolvedValue(['en']),
+}))
+
+vi.mock('next/cache', () => ({
+  io: mocks.io,
 }))
 
 vi.mock('@/lib/public-shell-rendering', () => ({
@@ -25,6 +32,10 @@ vi.mock('@/lib/db/queries/settings', () => ({
 
 vi.mock('@/lib/geoblock-settings', () => ({
   loadBlockedCountries: mocks.loadBlockedCountries,
+}))
+
+vi.mock('@/lib/lifi', () => ({
+  getLiFiServerActions: vi.fn().mockResolvedValue({ getChains: mocks.getLiFiChains }),
 }))
 
 vi.mock('@/i18n/locale-settings', () => ({
@@ -45,5 +56,17 @@ describe('mutable API response caching', () => {
     const response = await handler()
 
     expect(response.headers.get('cache-control')).toBe(MUTABLE_API_CACHE_CONTROL)
+  })
+
+  it.each([
+    ['affiliate settings', getAffiliateSettings],
+    ['arbitrage config', getArbitrageConfig],
+    ['geoblock settings', getGeoblockSettings],
+    ['LI.FI chains', getLiFiChains],
+    ['locales', getLocales],
+  ])('always loads %s at request time', async (_, handler) => {
+    await handler()
+
+    expect(mocks.io).toHaveBeenCalledOnce()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Polymarket arbitrage toggle by ensuring the arbitrage config API is dynamically rendered. Replaces `deferPublicShellPrerenderIfNeeded` with `io` from `next/cache` on five mutable API routes so they always load at request time. Adds a unit test to confirm each route calls `io`.

<sup>Written for commit 7b2a333358b855c8b1cb4922f23e8914fd5a5e4e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

