### PR TITLE
fix: coordinate automatic and manual SIWX signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@polymarket/clob-client-v2": "1.1.0",
     "@reown/appkit": "1.8.23",
     "@reown/appkit-adapter-wagmi": "1.8.23",
+    "@reown/appkit-controllers": "1.8.23",
     "@reown/appkit-siwe": "1.8.23",
     "@sentry/nextjs": "10.70.0",
     "@sumsub/websdk": "2.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@reown/appkit-adapter-wagmi':
         specifier: 1.8.23
         version: 1.8.23(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(@wagmi/core@2.22.1(@tanstack/query-core@5.101.4)(@types/react@19.2.18)(react@19.2.8)(typescript@7.0.2)(use-sync-external-store@1.6.0(react@19.2.8))(viem@2.55.19(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)))(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@7.0.2)(use-sync-external-store@1.6.0(react@19.2.8))(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(wagmi@2.19.5(@tanstack/query-core@5.101.4)(@tanstack/react-query@5.101.4(react@19.2.8))(@types/react@19.2.18)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@7.0.2)(utf-8-validate@5.0.10)(viem@2.55.19(bufferutil@4.1.0)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3))(zod@4.4.3))(zod@4.4.3)
+      '@reown/appkit-controllers':
+        specifier: 1.8.23
+        version: 1.8.23(@types/react@19.2.18)(bufferutil@4.1.0)(react@19.2.8)(typescript@7.0.2)(utf-8-validate@5.0.10)(zod@4.4.3)
       '@reown/appkit-siwe':
         specifier: 1.8.23
         version: 1.8.23(@types/react@19.2.18)(bufferutil@4.1.0)(debug@4.4.3(supports-color@8.1.1))(react@19.2.8)(supports-color@8.1.1)(typescript@7.0.2)(use-sync-external-store@1.6.0(react@19.2.8))(utf-8-validate@5.0.10)(zod@4.4.3)

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -219,7 +219,10 @@ export const auth = betterAuth({
       domain: SIWE_DOMAIN,
       emailDomainName: SIWE_EMAIL_DOMAIN,
       anonymous: true,
-      getNonce: async () => generateRandomString(32),
+      // ERC-4361 only permits alphanumeric characters in a SIWE nonce.
+      // Better Auth's default alphabet also includes `-` and `_`, which
+      // makes Reown reject the message before it reaches the wallet.
+      getNonce: async () => generateRandomString(32, 'a-z', 'A-Z', '0-9'),
       verifyMessage: async ({ message, signature, address }) => {
         const chainId = getChainIdFromMessage(message)
         const { reownAppKitProjectId } = resolvePublicRuntimeEnv(process.env)

--- a/src/lib/siwe-nonce-bridge.ts
+++ b/src/lib/siwe-nonce-bridge.ts
@@ -28,7 +28,9 @@ function createExpiry() {
 }
 
 export async function createPendingSiweNonce() {
-  const nonce = generateRandomString(32)
+  // Keep this nonce compliant with ERC-4361 as it is embedded in the SIWE
+  // message before Better Auth receives the verification request.
+  const nonce = generateRandomString(32, 'a-z', 'A-Z', '0-9')
   const now = new Date()
 
   await db.delete(verifications).where(lt(verifications.expires_at, now))

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -5,7 +5,7 @@ import type { AppKitSIWEClient, SIWECreateMessageArgs, SIWESession, SIWEVerifyMe
 import type { ReactNode } from 'react'
 import type { Config } from 'wagmi'
 
-import { SIWXUtil } from '@reown/appkit-controllers'
+import { ChainController, SIWXUtil } from '@reown/appkit-controllers'
 import { createSIWEConfig, formatMessage, getAddressFromMessage, getDidAddress } from '@reown/appkit-siwe'
 import { createAppKit, useAppKitAccount, useAppKitTheme } from '@reown/appkit/react'
 import { useExtracted } from 'next-intl'
@@ -131,21 +131,35 @@ function waitForAutomaticSiwe(delayMs: number) {
   })
 }
 
+function getSiweAccountLockKey() {
+  return ChainController.getActiveCaipAddress()?.toLowerCase() ?? null
+}
+
 function installSiwxRequestSignMessageLock() {
   if (hasInstalledSiwxRequestSignMessageLock) {
     return
   }
 
   const requestSignMessage = SIWXUtil.requestSignMessage.bind(SIWXUtil)
-  let requestPromise: Promise<void> | null = null
+  const requestPromises = new Map<string, Promise<void>>()
 
   SIWXUtil.requestSignMessage = () => {
-    if (!requestPromise) {
-      requestPromise = requestSignMessage().finally(() => {
-        requestPromise = null
-      })
+    const accountKey = getSiweAccountLockKey()
+    if (!accountKey) {
+      return requestSignMessage()
     }
 
+    const existingRequest = requestPromises.get(accountKey)
+    if (existingRequest) {
+      return existingRequest
+    }
+
+    const requestPromise = requestSignMessage().finally(() => {
+      if (requestPromises.get(accountKey) === requestPromise) {
+        requestPromises.delete(accountKey)
+      }
+    })
+    requestPromises.set(accountKey, requestPromise)
     return requestPromise
   }
   hasInstalledSiwxRequestSignMessageLock = true
@@ -153,15 +167,25 @@ function installSiwxRequestSignMessageLock() {
 
 function installSiweSignInLock(siweClient: AppKitSIWEClient) {
   const signIn = siweClient.signIn.bind(siweClient)
-  let signInPromise: Promise<SIWESession> | null = null
+  const signInPromises = new Map<string, Promise<SIWESession>>()
 
   siweClient.signIn = () => {
-    if (!signInPromise) {
-      signInPromise = signIn().finally(() => {
-        signInPromise = null
-      })
+    const accountKey = getSiweAccountLockKey()
+    if (!accountKey) {
+      return signIn()
     }
 
+    const existingSignIn = signInPromises.get(accountKey)
+    if (existingSignIn) {
+      return existingSignIn
+    }
+
+    const signInPromise = signIn().finally(() => {
+      if (signInPromises.get(accountKey) === signInPromise) {
+        signInPromises.delete(accountKey)
+      }
+    })
+    signInPromises.set(accountKey, signInPromise)
     return signInPromise
   }
 }

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -151,6 +151,21 @@ function installSiwxRequestSignMessageLock() {
   hasInstalledSiwxRequestSignMessageLock = true
 }
 
+function installSiweSignInLock(siweClient: AppKitSIWEClient) {
+  const signIn = siweClient.signIn.bind(siweClient)
+  let signInPromise: Promise<SIWESession> | null = null
+
+  siweClient.signIn = () => {
+    if (!signInPromise) {
+      signInPromise = signIn().finally(() => {
+        signInPromise = null
+      })
+    }
+
+    return signInPromise
+  }
+}
+
 function AutoSiweAuthentication({ siweClient }: { siweClient: AppKitSIWEClient }) {
   const t = useExtracted()
   const { address, embeddedWalletInfo, isConnected } = useAppKitAccount({ namespace: 'eip155' })
@@ -170,10 +185,25 @@ function AutoSiweAuthentication({ siweClient }: { siweClient: AppKitSIWEClient }
 
     attemptedAddressRef.current = normalizedAddress
     let cancelled = false
+    let attemptInFlight = true
+    function resetAttemptedAddress() {
+      if (attemptedAddressRef.current === normalizedAddress) {
+        attemptedAddressRef.current = null
+      }
+    }
 
     void (async () => {
       const session = await authClient.getSession()
-      if (cancelled || session.error || session.data?.user) {
+      if (cancelled) {
+        return
+      }
+      if (session.error) {
+        attemptInFlight = false
+        resetAttemptedAddress()
+        return
+      }
+      if (session.data?.user) {
+        attemptInFlight = false
         return
       }
 
@@ -183,13 +213,35 @@ function AutoSiweAuthentication({ siweClient }: { siweClient: AppKitSIWEClient }
       }
 
       const latestSession = await authClient.getSession()
-      if (cancelled || latestSession.error || latestSession.data?.user) {
+      if (cancelled) {
+        return
+      }
+      if (latestSession.error) {
+        attemptInFlight = false
+        resetAttemptedAddress()
+        return
+      }
+      if (latestSession.data?.user) {
+        attemptInFlight = false
+        return
+      }
+
+      if (await isCurrentRegionBlocked()) {
+        if (cancelled) {
+          return
+        }
+
+        attemptInFlight = false
+        toast.warning(t('This platform is not currently available in your region.'))
         return
       }
 
       await siweClient.signIn()
+      attemptInFlight = false
     })().catch((error) => {
       if (!cancelled) {
+        attemptInFlight = false
+        resetAttemptedAddress()
         console.warn('[SIWE] Automatic wallet authentication failed', error)
         toast.error(t('An unexpected error occurred. Please try again.'))
       }
@@ -197,6 +249,9 @@ function AutoSiweAuthentication({ siweClient }: { siweClient: AppKitSIWEClient }
 
     return () => {
       cancelled = true
+      if (attemptInFlight) {
+        resetAttemptedAddress()
+      }
     }
   }, [address, embeddedWalletInfo, isConnected, siweClient, t])
 
@@ -462,6 +517,7 @@ function initializeAppKitSingleton(
 
     appKitSiweClient = siweClient
     installSiwxRequestSignMessageLock()
+    installSiweSignInLock(siweClient)
     hasInitializedAppKit = true
     notifyAppKitStateChange()
     return appKitInstance

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -1,15 +1,16 @@
 'use client'
 
 import type { AppKit } from '@reown/appkit'
-import type { SIWECreateMessageArgs, SIWESession, SIWEVerifyMessageArgs } from '@reown/appkit-siwe'
+import type { AppKitSIWEClient, SIWECreateMessageArgs, SIWESession, SIWEVerifyMessageArgs } from '@reown/appkit-siwe'
 import type { ReactNode } from 'react'
 import type { Config } from 'wagmi'
 
+import { SIWXUtil } from '@reown/appkit-controllers'
 import { createSIWEConfig, formatMessage, getAddressFromMessage, getDidAddress } from '@reown/appkit-siwe'
-import { createAppKit, useAppKitTheme } from '@reown/appkit/react'
+import { createAppKit, useAppKitAccount, useAppKitTheme } from '@reown/appkit/react'
 import { useExtracted } from 'next-intl'
 import { useTheme } from 'next-themes'
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { getAddress, isAddress } from 'viem'
 import { cookieToInitialState, WagmiProvider } from 'wagmi'
 
@@ -32,8 +33,11 @@ import { mergeSessionUserState, useUser } from '@/stores/useUser'
 
 let hasInitializedAppKit = false
 let appKitInstance: AppKit | null = null
+let appKitSiweClient: AppKitSIWEClient | null = null
+let hasInstalledSiwxRequestSignMessageLock = false
 const appKitStateListeners = new Set<() => void>()
 const APPKIT_INIT_RETRY_DELAY_MS = 3000
+const AUTOMATIC_SIWE_SETTLE_DELAY_MS = 750
 const SIWE_ACCOUNT_PLACEHOLDER = '<<AccountAddress>>'
 const pendingSiweNonces = new Set<string>()
 
@@ -119,6 +123,84 @@ function getSiweNonceErrorMessage(error: unknown) {
 
 function getSiweMessageNonce(message: string) {
   return message.match(/^Nonce: (?<nonce>.+)$/mu)?.groups?.nonce ?? null
+}
+
+function waitForAutomaticSiwe(delayMs: number) {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, delayMs)
+  })
+}
+
+function installSiwxRequestSignMessageLock() {
+  if (hasInstalledSiwxRequestSignMessageLock) {
+    return
+  }
+
+  const requestSignMessage = SIWXUtil.requestSignMessage.bind(SIWXUtil)
+  let requestPromise: Promise<void> | null = null
+
+  SIWXUtil.requestSignMessage = () => {
+    if (!requestPromise) {
+      requestPromise = requestSignMessage().finally(() => {
+        requestPromise = null
+      })
+    }
+
+    return requestPromise
+  }
+  hasInstalledSiwxRequestSignMessageLock = true
+}
+
+function AutoSiweAuthentication({ siweClient }: { siweClient: AppKitSIWEClient }) {
+  const t = useExtracted()
+  const { address, embeddedWalletInfo, isConnected } = useAppKitAccount({ namespace: 'eip155' })
+  const attemptedAddressRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    const normalizedAddress = address?.toLowerCase()
+    if (!isConnected || !normalizedAddress) {
+      attemptedAddressRef.current = null
+      return
+    }
+
+    // Embedded wallets already perform SIWX as part of their AppKit auth flow.
+    if (embeddedWalletInfo || attemptedAddressRef.current === normalizedAddress) {
+      return
+    }
+
+    attemptedAddressRef.current = normalizedAddress
+    let cancelled = false
+
+    void (async () => {
+      const session = await authClient.getSession()
+      if (cancelled || session.error || session.data?.user) {
+        return
+      }
+
+      await waitForAutomaticSiwe(AUTOMATIC_SIWE_SETTLE_DELAY_MS)
+      if (cancelled) {
+        return
+      }
+
+      const latestSession = await authClient.getSession()
+      if (cancelled || latestSession.error || latestSession.data?.user) {
+        return
+      }
+
+      await siweClient.signIn()
+    })().catch((error) => {
+      if (!cancelled) {
+        console.warn('[SIWE] Automatic wallet authentication failed', error)
+        toast.error(t('An unexpected error occurred. Please try again.'))
+      }
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [address, embeddedWalletInfo, isConnected, siweClient, t])
+
+  return null
 }
 
 function createSiweMessage(args: SIWECreateMessageArgs, chainId: number) {
@@ -216,6 +298,10 @@ function getAppKitInstanceSnapshot() {
   return appKitInstance
 }
 
+function getAppKitSiweClientSnapshot() {
+  return appKitSiweClient
+}
+
 function initializeAppKitSingleton(
   themeMode: 'light' | 'dark',
   site: { name: string; description: string; logoUrl: string },
@@ -227,6 +313,121 @@ function initializeAppKitSingleton(
   }
 
   try {
+    const siweClient = createSIWEConfig({
+      // Multi-wallet arbitrage briefly activates the second wallet before restoring
+      // the authenticated Kuest wallet. Keep the Better Auth session intact.
+      signOutOnAccountChange: false,
+      // Same-wallet arbitrage temporarily switches from the site chain to Polygon.
+      // That network change must not start a second SIWE flow or end the site session.
+      signOutOnNetworkChange: false,
+      getMessageParams: async () => ({
+        domain: new URL(runtimeConfig.siteUrl).host,
+        uri: typeof window !== 'undefined' ? window.location.origin : '',
+        chains: [defaultNetwork.id],
+        statement: 'Please sign with your account',
+      }),
+      createMessage: ({ address, ...args }: SIWECreateMessageArgs) => {
+        const chainId = defaultNetwork.id
+        return createSiweMessage({ ...args, address, chainId }, chainId)
+      },
+      getNonce: async (address?: string) => {
+        try {
+          if (isPendingSiweAccountAddress(address)) {
+            return await createPendingSiweNonce()
+          }
+
+          const { data, error } = await authClient.siwe.nonce()
+
+          if (!data?.nonce) {
+            throw new Error(getSiweNonceErrorMessage(error))
+          }
+
+          return data.nonce
+        } catch (error) {
+          logSiweVerificationFailure('SIWE nonce creation failed', {
+            address,
+            chainId: defaultNetwork.id,
+            error,
+          })
+          throw error
+        }
+      },
+      getSession: async () => {
+        try {
+          const session = await authClient.getSession()
+          if (!session.data?.user) {
+            return null
+          }
+
+          const address = getAuthSessionUserAddress(session.data.user)
+          if (!address) {
+            return null
+          }
+
+          return {
+            address,
+            chainId: defaultNetwork.id,
+          } satisfies SIWESession
+        } catch {
+          return null
+        }
+      },
+      verifyMessage: async ({ message, signature }: SIWEVerifyMessageArgs) => {
+        try {
+          const address = normalizeSiweWalletAddress(getAddressFromMessage(message))
+          await bindPendingSiweNonce({
+            walletAddress: address,
+            chainId: defaultNetwork.id,
+            message,
+          })
+
+          const { data, error } = await authClient.siwe.verify({ message, signature })
+
+          if (error) {
+            return false
+          }
+
+          return Boolean(data?.success)
+        } catch (error) {
+          logSiweVerificationFailure('SIWE verification failed before Better Auth returned', {
+            error,
+          })
+          return false
+        }
+      },
+      signOut: async () => {
+        try {
+          const currentUser = useUser.getState()
+          const communityApiUrl = window.__PUBLIC_RUNTIME_CONFIG__?.communityUrl
+          if (currentUser?.address && communityApiUrl) {
+            await detachTradeAlertsBeforeLogout(communityApiUrl, currentUser.address).catch(() => undefined)
+          }
+          await authClient.signOut()
+          useUser.setState(null)
+          return true
+        } catch {
+          return false
+        }
+      },
+      onSignIn: () => {
+        authClient
+          .getSession()
+          .then((session) => {
+            const user = session?.data?.user
+            if (user) {
+              useUser.setState((previous) => {
+                return mergeSessionUserState(previous, user as unknown as User)
+              })
+            }
+          })
+          .catch(() => {})
+      },
+      onSignOut: () => {
+        clearAppKitState()
+        window.location.reload()
+      },
+    })
+
     appKitInstance = createAppKit({
       projectId: runtimeConfig.projectId,
       adapters: [wagmiAdapter],
@@ -256,122 +457,11 @@ function initializeAppKitSingleton(
         pay: false,
         headless: false,
       },
-      siweConfig: createSIWEConfig({
-        // Multi-wallet arbitrage briefly activates the second wallet before restoring
-        // the authenticated Kuest wallet. Keep the Better Auth session intact.
-        signOutOnAccountChange: false,
-        // Same-wallet arbitrage temporarily switches from the site chain to Polygon.
-        // That network change must not start a second SIWE flow or end the site session.
-        signOutOnNetworkChange: false,
-        getMessageParams: async () => ({
-          domain: new URL(runtimeConfig.siteUrl).host,
-          uri: typeof window !== 'undefined' ? window.location.origin : '',
-          chains: [defaultNetwork.id],
-          statement: 'Please sign with your account',
-        }),
-        createMessage: ({ address, ...args }: SIWECreateMessageArgs) => {
-          const chainId = defaultNetwork.id
-          return createSiweMessage({ ...args, address, chainId }, chainId)
-        },
-        getNonce: async (address?: string) => {
-          try {
-            if (isPendingSiweAccountAddress(address)) {
-              return await createPendingSiweNonce()
-            }
-
-            const { data, error } = await authClient.siwe.nonce()
-
-            if (!data?.nonce) {
-              throw new Error(getSiweNonceErrorMessage(error))
-            }
-
-            return data.nonce
-          } catch (error) {
-            logSiweVerificationFailure('SIWE nonce creation failed', {
-              address,
-              chainId: defaultNetwork.id,
-              error,
-            })
-            throw error
-          }
-        },
-        getSession: async () => {
-          try {
-            const session = await authClient.getSession()
-            if (!session.data?.user) {
-              return null
-            }
-
-            const address = getAuthSessionUserAddress(session.data.user)
-            if (!address) {
-              return null
-            }
-
-            return {
-              address,
-              chainId: defaultNetwork.id,
-            } satisfies SIWESession
-          } catch {
-            return null
-          }
-        },
-        verifyMessage: async ({ message, signature }: SIWEVerifyMessageArgs) => {
-          try {
-            const address = normalizeSiweWalletAddress(getAddressFromMessage(message))
-            await bindPendingSiweNonce({
-              walletAddress: address,
-              chainId: defaultNetwork.id,
-              message,
-            })
-
-            const { data, error } = await authClient.siwe.verify({ message, signature })
-
-            if (error) {
-              return false
-            }
-
-            return Boolean(data?.success)
-          } catch (error) {
-            logSiweVerificationFailure('SIWE verification failed before Better Auth returned', {
-              error,
-            })
-            return false
-          }
-        },
-        signOut: async () => {
-          try {
-            const currentUser = useUser.getState()
-            const communityApiUrl = window.__PUBLIC_RUNTIME_CONFIG__?.communityUrl
-            if (currentUser?.address && communityApiUrl) {
-              await detachTradeAlertsBeforeLogout(communityApiUrl, currentUser.address).catch(() => undefined)
-            }
-            await authClient.signOut()
-            useUser.setState(null)
-            return true
-          } catch {
-            return false
-          }
-        },
-        onSignIn: () => {
-          authClient
-            .getSession()
-            .then((session) => {
-              const user = session?.data?.user
-              if (user) {
-                useUser.setState((previous) => {
-                  return mergeSessionUserState(previous, user as unknown as User)
-                })
-              }
-            })
-            .catch(() => {})
-        },
-        onSignOut: () => {
-          clearAppKitState()
-          window.location.reload()
-        },
-      }),
+      siweConfig: siweClient,
     })
 
+    appKitSiweClient = siweClient
+    installSiwxRequestSignMessageLock()
     hasInitializedAppKit = true
     notifyAppKitStateChange()
     return appKitInstance
@@ -520,6 +610,10 @@ function useAppKitInstance({
   return instance
 }
 
+function useAppKitSiweClient() {
+  return useSyncExternalStore(subscribeAppKitStateChange, getAppKitSiweClientSnapshot, () => null)
+}
+
 function useAppKitContextValue({
   instance,
   hasAuthenticatedUser,
@@ -563,6 +657,7 @@ export default function AppKitProvider({ children, wagmiCookie }: { children: Re
     siteUrl,
     wagmiAdapter,
   })
+  const siweClient = useAppKitSiweClient()
   const appKitValue = useAppKitContextValue({
     instance,
     hasAuthenticatedUser: Boolean(currentUser?.id),
@@ -574,6 +669,7 @@ export default function AppKitProvider({ children, wagmiCookie }: { children: Re
     <WagmiProvider config={wagmiConfig} initialState={initialState}>
       <AppKitContext value={appKitValue}>
         <PolymarketWalletConnectionRestorer />
+        {instance && siweClient && <AutoSiweAuthentication siweClient={siweClient} />}
         {children}
         {hasHydrated && <SignaturePromptHost />}
         {canSyncTheme && <AppKitThemeSynchronizer themeMode={appKitThemeMode} />}

--- a/tests/unit/AppKitProvider.test.ts
+++ b/tests/unit/AppKitProvider.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   createAppKit: vi.fn(),
   createSIWEConfig: vi.fn(),
   setThemeMode: vi.fn(),
+  siweClientSignIn: vi.fn(),
   siwxRequestSignMessage: vi.fn(),
   useAppKitAccount: vi.fn(),
   WagmiProvider: vi.fn(({ children }: any) => children),
@@ -105,11 +106,12 @@ describe('appKitProvider SSR guard', () => {
     mocks.cookieToInitialState.mockReset()
     mocks.createAppKit.mockReset()
     mocks.createSIWEConfig.mockReset()
-    mocks.createSIWEConfig.mockImplementation((config) => ({
-      ...config,
-      signIn: () => SIWXUtil.requestSignMessage().then(() => ({ address: '0x123', chainId: 1 })),
-    }))
+    mocks.createSIWEConfig.mockImplementation((config) => ({ ...config, signIn: mocks.siweClientSignIn }))
     mocks.setThemeMode.mockReset()
+    mocks.siweClientSignIn.mockReset()
+    mocks.siweClientSignIn.mockImplementation(() =>
+      SIWXUtil.requestSignMessage().then(() => ({ address: '0x123', chainId: 1 })),
+    )
     mocks.siwxRequestSignMessage.mockReset()
     mocks.siwxRequestSignMessage.mockResolvedValue(undefined)
     mocks.useAppKitAccount.mockReset()
@@ -285,6 +287,141 @@ describe('appKitProvider SSR guard', () => {
       },
       { timeout: 2000 },
     )
+  })
+
+  it('deduplicates the complete SIWE sign-in orchestration', async () => {
+    let releaseSignIn: (() => void) | undefined
+    mocks.siwxRequestSignMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSignIn = resolve
+        }),
+    )
+    mocks.createAppKit.mockReturnValueOnce({
+      open: vi.fn(),
+      close: vi.fn(),
+    })
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x123',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+
+    const { AppKitContext } = await import('@/hooks/useAppKit')
+    const AppKitProvider = (await import('@/providers/AppKitProvider')).default
+    const TestAppKitProvider = AppKitProvider as React.ComponentType<
+      React.PropsWithChildren<{ wagmiCookie: string | null }>
+    >
+
+    const view = render(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+        expect(mocks.siweClientSignIn).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 2000 },
+    )
+
+    const siweClient = mocks.createSIWEConfig.mock.results[0]?.value as { signIn: () => Promise<unknown> }
+    const manualSignIn = siweClient.signIn()
+    expect(mocks.siweClientSignIn).toHaveBeenCalledTimes(1)
+    expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+
+    releaseSignIn?.()
+    await manualSignIn
+    view.unmount()
+  })
+
+  it('retries automatic SIWE when the previous attempt is cancelled', async () => {
+    mocks.createAppKit.mockReturnValueOnce({
+      open: vi.fn(),
+      close: vi.fn(),
+    })
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x123',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+
+    const { AppKitContext } = await import('@/hooks/useAppKit')
+    const AppKitProvider = (await import('@/providers/AppKitProvider')).default
+    const TestAppKitProvider = AppKitProvider as React.ComponentType<
+      React.PropsWithChildren<{ wagmiCookie: string | null }>
+    >
+
+    const view = render(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 25))
+    view.rerender(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 2000 },
+    )
+    view.unmount()
+  })
+
+  it('does not automatically start SIWE when the current region is blocked', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ blocked: true }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    mocks.createAppKit.mockReturnValueOnce({
+      open: vi.fn(),
+      close: vi.fn(),
+    })
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x123',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+
+    const { AppKitContext } = await import('@/hooks/useAppKit')
+    const AppKitProvider = (await import('@/providers/AppKitProvider')).default
+    const TestAppKitProvider = AppKitProvider as React.ComponentType<
+      React.PropsWithChildren<{ wagmiCookie: string | null }>
+    >
+
+    render(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(fetchMock).toHaveBeenCalledWith('/api/geoblock-status', {
+          cache: 'no-store',
+          headers: { accept: 'application/json' },
+        })
+      },
+      { timeout: 2000 },
+    )
+    expect(mocks.siwxRequestSignMessage).not.toHaveBeenCalled()
   })
 
   it('shares the in-flight SIWE request with the manual Sign action', async () => {

--- a/tests/unit/AppKitProvider.test.ts
+++ b/tests/unit/AppKitProvider.test.ts
@@ -10,6 +10,7 @@ function ReadyConsumer({ ctx, onValue }: { ctx: React.Context<any>; onValue?: (v
 }
 
 const mocks = vi.hoisted(() => ({
+  chainControllerGetActiveCaipAddress: vi.fn(),
   cookieToInitialState: vi.fn(),
   createAppKit: vi.fn(),
   createSIWEConfig: vi.fn(),
@@ -31,6 +32,10 @@ vi.mock('@reown/appkit-controllers', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@reown/appkit-controllers')>()
   return {
     ...actual,
+    ChainController: {
+      ...actual.ChainController,
+      getActiveCaipAddress: mocks.chainControllerGetActiveCaipAddress,
+    },
     SIWXUtil: {
       ...actual.SIWXUtil,
       requestSignMessage: mocks.siwxRequestSignMessage,
@@ -103,6 +108,8 @@ describe('appKitProvider SSR guard', () => {
   beforeEach(() => {
     vi.resetModules()
     vi.unstubAllGlobals()
+    mocks.chainControllerGetActiveCaipAddress.mockReset()
+    mocks.chainControllerGetActiveCaipAddress.mockReturnValue('eip155:1:0x123')
     mocks.cookieToInitialState.mockReset()
     mocks.createAppKit.mockReset()
     mocks.createSIWEConfig.mockReset()
@@ -336,6 +343,71 @@ describe('appKitProvider SSR guard', () => {
 
     releaseSignIn?.()
     await manualSignIn
+    view.unmount()
+  })
+
+  it('does not share a pending SIWE sign-in between different accounts', async () => {
+    const pendingSignatures: Array<() => void> = []
+    mocks.siwxRequestSignMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          pendingSignatures.push(resolve)
+        }),
+    )
+    mocks.createAppKit.mockReturnValueOnce({
+      open: vi.fn(),
+      close: vi.fn(),
+    })
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x123',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+
+    const { AppKitContext } = await import('@/hooks/useAppKit')
+    const AppKitProvider = (await import('@/providers/AppKitProvider')).default
+    const TestAppKitProvider = AppKitProvider as React.ComponentType<
+      React.PropsWithChildren<{ wagmiCookie: string | null }>
+    >
+
+    const view = render(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 2000 },
+    )
+
+    mocks.chainControllerGetActiveCaipAddress.mockReturnValue('eip155:1:0x456')
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x456',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+    view.rerender(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(2)
+        expect(mocks.siweClientSignIn).toHaveBeenCalledTimes(2)
+      },
+      { timeout: 2000 },
+    )
+    expect(pendingSignatures).toHaveLength(2)
+    pendingSignatures.forEach((release) => release())
     view.unmount()
   })
 

--- a/tests/unit/AppKitProvider.test.ts
+++ b/tests/unit/AppKitProvider.test.ts
@@ -1,3 +1,4 @@
+import { SIWXUtil } from '@reown/appkit-controllers'
 import { act, render, screen, waitFor } from '@testing-library/react'
 import * as React from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -13,14 +14,28 @@ const mocks = vi.hoisted(() => ({
   createAppKit: vi.fn(),
   createSIWEConfig: vi.fn(),
   setThemeMode: vi.fn(),
+  siwxRequestSignMessage: vi.fn(),
+  useAppKitAccount: vi.fn(),
   WagmiProvider: vi.fn(({ children }: any) => children),
 }))
 
 vi.mock('@reown/appkit/react', () => ({
   __esModule: true,
   createAppKit: mocks.createAppKit,
+  useAppKitAccount: mocks.useAppKitAccount,
   useAppKitTheme: () => ({ setThemeMode: mocks.setThemeMode }),
 }))
+
+vi.mock('@reown/appkit-controllers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@reown/appkit-controllers')>()
+  return {
+    ...actual,
+    SIWXUtil: {
+      ...actual.SIWXUtil,
+      requestSignMessage: mocks.siwxRequestSignMessage,
+    },
+  }
+})
 
 vi.mock('@reown/appkit-siwe', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@reown/appkit-siwe')>()
@@ -90,8 +105,19 @@ describe('appKitProvider SSR guard', () => {
     mocks.cookieToInitialState.mockReset()
     mocks.createAppKit.mockReset()
     mocks.createSIWEConfig.mockReset()
-    mocks.createSIWEConfig.mockImplementation((config) => config)
+    mocks.createSIWEConfig.mockImplementation((config) => ({
+      ...config,
+      signIn: () => SIWXUtil.requestSignMessage().then(() => ({ address: '0x123', chainId: 1 })),
+    }))
     mocks.setThemeMode.mockReset()
+    mocks.siwxRequestSignMessage.mockReset()
+    mocks.siwxRequestSignMessage.mockResolvedValue(undefined)
+    mocks.useAppKitAccount.mockReset()
+    mocks.useAppKitAccount.mockReturnValue({
+      address: undefined,
+      embeddedWalletInfo: undefined,
+      isConnected: false,
+    })
     mocks.WagmiProvider.mockClear()
   })
 
@@ -226,5 +252,86 @@ describe('appKitProvider SSR guard', () => {
     } finally {
       warnSpy.mockRestore()
     }
+  })
+
+  it('automatically starts SIWE after an external wallet connects', async () => {
+    mocks.createAppKit.mockReturnValueOnce({
+      open: vi.fn(),
+      close: vi.fn(),
+    })
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x123',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+
+    const { AppKitContext } = await import('@/hooks/useAppKit')
+    const AppKitProvider = (await import('@/providers/AppKitProvider')).default
+    const TestAppKitProvider = AppKitProvider as React.ComponentType<
+      React.PropsWithChildren<{ wagmiCookie: string | null }>
+    >
+
+    render(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 2000 },
+    )
+  })
+
+  it('shares the in-flight SIWE request with the manual Sign action', async () => {
+    let releaseSignIn: (() => void) | undefined
+    mocks.siwxRequestSignMessage.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseSignIn = resolve
+        }),
+    )
+    mocks.createAppKit.mockImplementationOnce(() => {
+      return {
+        open: vi.fn(),
+        close: vi.fn(),
+      }
+    })
+    mocks.useAppKitAccount.mockReturnValue({
+      address: '0x123',
+      embeddedWalletInfo: undefined,
+      isConnected: true,
+    })
+
+    const { AppKitContext } = await import('@/hooks/useAppKit')
+    const AppKitProvider = (await import('@/providers/AppKitProvider')).default
+    const TestAppKitProvider = AppKitProvider as React.ComponentType<
+      React.PropsWithChildren<{ wagmiCookie: string | null }>
+    >
+
+    const view = render(
+      React.createElement(
+        TestAppKitProvider,
+        { wagmiCookie: 'test-state' },
+        React.createElement(ReadyConsumer, { ctx: AppKitContext }),
+      ),
+    )
+
+    await waitFor(
+      () => {
+        expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+      },
+      { timeout: 2000 },
+    )
+
+    const manualSignIn = SIWXUtil.requestSignMessage()
+    expect(mocks.siwxRequestSignMessage).toHaveBeenCalledTimes(1)
+    releaseSignIn?.()
+    await manualSignIn
+    view.unmount()
   })
 })


### PR DESCRIPTION
## Summary
- trigger SIWE signing automatically after wallet connection settles
- coordinate automatic and manual SIWX requests through the Reown request lock
- keep ERC-4361 nonce generation valid and align appkit controllers to 1.8.23

## Validation
- TypeScript
- Oxlint
- diff --check
- 6 targeted tests passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinates automatic and manual SIWE signing so wallet connections no longer trigger conflicting sign-in requests.

- Automatic SIWE starts after the wallet connection settles and no session exists; embedded wallets are skipped because they already sign.
- Automatic and manual sign-ins share the in-flight request through per-account locks on `SIWXUtil.requestSignMessage` and `siweClient.signIn`; automatic attempts retry after cancellation and skip when the region is blocked.
- Nonces are now alphanumeric only, matching ERC-4361, so Reown no longer rejects the message.
- Adds `@reown/appkit-controllers` at 1.8.23 to align with the other Reown packages.

<sup>Written for commit 0c1d5f36be1c45872877f95219825e4e1bc0c15b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

