### PR TITLE
fix: prefill onboarding email from Reown login

### DIFF
--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -439,6 +439,15 @@ function EmailDialog({
   const lastSyncedDefaultValueRef = useRef(defaultValue)
 
   useEffect(
+    function resetEmailEditStateWhenClosed() {
+      if (!open) {
+        emailEditedRef.current = false
+      }
+    },
+    [open],
+  )
+
+  useEffect(
     function syncEmailDefaultValue() {
       const normalizedDefaultValue = defaultValue.trim()
       if (!open || !normalizedDefaultValue || emailEditedRef.current) {

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -435,12 +435,13 @@ function EmailDialog({
 }) {
   const t = useExtracted()
   const [email, setEmail] = useState(defaultValue)
+  const emailEditedRef = useRef(false)
   const lastSyncedDefaultValueRef = useRef(defaultValue)
 
   useEffect(
     function syncEmailDefaultValue() {
       const normalizedDefaultValue = defaultValue.trim()
-      if (!open || !normalizedDefaultValue) {
+      if (!open || !normalizedDefaultValue || emailEditedRef.current) {
         return
       }
 
@@ -478,7 +479,10 @@ function EmailDialog({
       <form className="mt-6 space-y-4" onSubmit={handleSubmit}>
         <Input
           value={email}
-          onChange={(event) => setEmail(event.target.value)}
+          onChange={(event) => {
+            emailEditedRef.current = true
+            setEmail(event.target.value)
+          }}
           placeholder={t('Email address')}
           type="email"
           className="h-12 text-base"

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -435,6 +435,27 @@ function EmailDialog({
 }) {
   const t = useExtracted()
   const [email, setEmail] = useState(defaultValue)
+  const lastSyncedDefaultValueRef = useRef(defaultValue)
+
+  useEffect(
+    function syncEmailDefaultValue() {
+      const normalizedDefaultValue = defaultValue.trim()
+      if (!open || !normalizedDefaultValue) {
+        return
+      }
+
+      const previousDefaultValue = lastSyncedDefaultValueRef.current.trim()
+      setEmail((currentEmail) => {
+        const normalizedCurrentEmail = currentEmail.trim()
+        if (!normalizedCurrentEmail || normalizedCurrentEmail === previousDefaultValue) {
+          return defaultValue
+        }
+        return currentEmail
+      })
+      lastSyncedDefaultValueRef.current = defaultValue
+    },
+    [defaultValue, open],
+  )
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -2,6 +2,7 @@
 
 import type { ReactNode } from 'react'
 
+import { useAppKitAccount } from '@reown/appkit/react'
 import { useExtracted } from 'next-intl'
 import { usePathname } from 'next/navigation'
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
@@ -498,6 +499,7 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
   } | null>(null)
   const { signTypedDataAsync } = useSignTypedData()
   const { signMessageAsync } = useSignMessage()
+  const { embeddedWalletInfo } = useAppKitAccount({ namespace: 'eip155' })
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const t = useExtracted()
   const signatureRejectedMessage = t('You rejected the signature request.')
@@ -604,6 +606,11 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
   const needsSumsub = sumsubStatus.effective && !sumsubApproved
   const needsSumsubForFlow = needsSumsub && !(sumsubStatus.enforcement === 'observe' && sumsubObserveDismissed)
   const tradingReady = isTradingReady({ onboardingStatus: status, sumsubLoaded, sumsubStatus })
+  const reownEmail =
+    embeddedWalletInfo?.authProvider === 'email' && hasUsableUserEmail(embeddedWalletInfo.user?.email)
+      ? (embeddedWalletInfo.user?.email?.trim() ?? '')
+      : ''
+  const emailDefaultValue = hasUsableUserEmail(user?.email) ? (user?.email?.trim() ?? '') : reownEmail
 
   const runPendingTradingReadyAction = useCallback(() => {
     const action = pendingTradingReadyActionRef.current
@@ -1872,7 +1879,7 @@ function TradingOnboardingProviderContent({ children, user }: TradingOnboardingP
         usernameError={usernameError}
         isUsernameSubmitting={isUsernameSubmitting}
         onUsernameSubmit={handleUsernameSubmit}
-        emailDefaultValue={hasUsableUserEmail(user?.email) ? (user?.email ?? '') : ''}
+        emailDefaultValue={emailDefaultValue}
         emailError={emailError}
         isEmailSubmitting={isEmailSubmitting}
         onEmailSubmit={handleEmailSubmit}


### PR DESCRIPTION
## Summary
- prefill the onboarding email field with the email from a Reown email login
- only use it for email-based embedded wallet login
- keep the existing app user email as the preferred value
- do not persist the email automatically

## Validation
- pre-push hooks passed: 1,963 tests and next build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefills the onboarding email field with the Reown login email when no app user email exists, and syncs it in if it arrives after the dialog opens. Manual edits stop the prefill from applying, and that edit state resets when the dialog closes so the prefill can apply again on the next open. The existing app user email still takes priority, the prefill only applies to email-based embedded wallet logins, and the email is not persisted automatically.

<sup>Written for commit 6095441b005f57b7379843675b59fabc4823aa1c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

