### PR TITLE
fix: polish event share dropdown

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/FilterToolbarSearchInput.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/FilterToolbarSearchInput.tsx
@@ -94,23 +94,28 @@ export default function FilterToolbarSearchInput({
       shellRef={searchShellRef}
       search={search}
       onSearchChange={onSearchChange}
-      onEscape={
-        collapsible
-          ? (currentInputValue, clearInput) => {
-              if (currentInputValue.trim()) {
-                clearInput()
-                onSearchChange('')
-                return
-              }
+      onEscape={(currentInputValue, clearInput) => {
+        if (!collapsible) {
+          if (!currentInputValue.trim() && currentInputValue !== search) {
+            onSearchChange('')
+          }
 
-              if (currentInputValue !== search) {
-                onSearchChange('')
-              }
+          return !currentInputValue.trim()
+        }
 
-              closeSearch()
-            }
-          : undefined
-      }
+        if (currentInputValue.trim()) {
+          clearInput()
+          onSearchChange('')
+          return true
+        }
+
+        if (currentInputValue !== search) {
+          onSearchChange('')
+        }
+
+        closeSearch()
+        return true
+      }}
     />
   )
 }
@@ -120,7 +125,7 @@ interface FilterToolbarSearchInputFieldProps {
   search: string
   shellRef?: RefObject<HTMLDivElement | null>
   onSearchChange: (search: string) => void
-  onEscape?: (currentInputValue: string, clearInput: () => void) => void
+  onEscape?: (currentInputValue: string, clearInput: () => void) => boolean
 }
 
 interface SearchDebounceTimeoutRef {
@@ -178,13 +183,15 @@ function useFilterToolbarSearchInputFieldState({
 
   const handleEscape = useCallback(
     function handleEscape(event: KeyboardEvent<HTMLInputElement>) {
-      clearPendingSearchDebounce(debounceTimeoutRef)
-
       const inputElement = event.currentTarget
-      onEscape?.(inputElement.value, () => {
+      const shouldCancelPendingSearch = onEscape?.(inputElement.value, () => {
         inputElement.value = ''
         lastSubmittedSearchRef.current = ''
       })
+
+      if (shouldCancelPendingSearch) {
+        clearPendingSearchDebounce(debounceTimeoutRef)
+      }
     },
     [onEscape],
   )

--- a/src/app/[locale]/(platform)/(home)/_components/FilterToolbarSearchInput.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/FilterToolbarSearchInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { ChangeEvent, RefObject } from 'react'
+import type { ChangeEvent, KeyboardEvent, RefObject } from 'react'
 
 import { SearchIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
@@ -41,7 +41,7 @@ export default function FilterToolbarSearchInput({
       return undefined
     }
 
-    function handlePointerDown(event: PointerEvent) {
+    function handleClick(event: MouseEvent) {
       const target = event.target
       if (!(target instanceof Node) || searchShellRef.current?.contains(target)) {
         return
@@ -64,8 +64,8 @@ export default function FilterToolbarSearchInput({
       closeSearch()
     }
 
-    window.addEventListener('pointerdown', handlePointerDown)
-    return () => window.removeEventListener('pointerdown', handlePointerDown)
+    window.addEventListener('click', handleClick)
+    return () => window.removeEventListener('click', handleClick)
   }, [closeSearch, collapsible, isOpen, onSearchChange, search])
 
   if (collapsible && !isOpen) {
@@ -94,14 +94,23 @@ export default function FilterToolbarSearchInput({
       shellRef={searchShellRef}
       search={search}
       onSearchChange={onSearchChange}
-      onEscape={(currentInputValue) => {
-        if (!currentInputValue.trim()) {
-          if (currentInputValue !== search) {
-            onSearchChange('')
-          }
-          closeSearch()
-        }
-      }}
+      onEscape={
+        collapsible
+          ? (currentInputValue, clearInput) => {
+              if (currentInputValue.trim()) {
+                clearInput()
+                onSearchChange('')
+                return
+              }
+
+              if (currentInputValue !== search) {
+                onSearchChange('')
+              }
+
+              closeSearch()
+            }
+          : undefined
+      }
     />
   )
 }
@@ -111,7 +120,7 @@ interface FilterToolbarSearchInputFieldProps {
   search: string
   shellRef?: RefObject<HTMLDivElement | null>
   onSearchChange: (search: string) => void
-  onEscape?: (currentInputValue: string) => void
+  onEscape?: (currentInputValue: string, clearInput: () => void) => void
 }
 
 interface SearchDebounceTimeoutRef {
@@ -125,7 +134,11 @@ function clearPendingSearchDebounce(debounceTimeoutRef: SearchDebounceTimeoutRef
   }
 }
 
-function useFilterToolbarSearchInputFieldState({ search, onSearchChange }: FilterToolbarSearchInputFieldProps) {
+function useFilterToolbarSearchInputFieldState({
+  onEscape,
+  search,
+  onSearchChange,
+}: FilterToolbarSearchInputFieldProps) {
   const debounceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const lastSubmittedSearchRef = useRef(search)
   const t = useExtracted()
@@ -163,7 +176,21 @@ function useFilterToolbarSearchInputFieldState({ search, onSearchChange }: Filte
     [onSearchChange],
   )
 
+  const handleEscape = useCallback(
+    function handleEscape(event: KeyboardEvent<HTMLInputElement>) {
+      clearPendingSearchDebounce(debounceTimeoutRef)
+
+      const inputElement = event.currentTarget
+      onEscape?.(inputElement.value, () => {
+        inputElement.value = ''
+        lastSubmittedSearchRef.current = ''
+      })
+    },
+    [onEscape],
+  )
+
   return {
+    handleEscape,
     inputRef,
     handleInputChange,
     searchPlaceholder: t('Search'),
@@ -177,7 +204,8 @@ function FilterToolbarSearchInputField({
   search,
   onSearchChange,
 }: FilterToolbarSearchInputFieldProps) {
-  const { inputRef, handleInputChange, searchPlaceholder } = useFilterToolbarSearchInputFieldState({
+  const { handleEscape, inputRef, handleInputChange, searchPlaceholder } = useFilterToolbarSearchInputFieldState({
+    onEscape,
     search,
     onSearchChange,
   })
@@ -195,7 +223,7 @@ function FilterToolbarSearchInputField({
         onChange={handleInputChange}
         onKeyDown={(event) => {
           if (event.key === 'Escape') {
-            onEscape?.(event.currentTarget.value)
+            handleEscape(event)
           }
         }}
         className={cn(

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -66,28 +66,6 @@ function getMarketEndTime(market: Event['markets'][number]) {
   return Number.isNaN(parsed) ? null : parsed
 }
 
-function sortMarketRowsByEndTime(rows: EventMarketRow[]) {
-  return rows
-    .map((row, index) => ({
-      row,
-      index,
-      endTime: getMarketEndTime(row.market),
-    }))
-    .sort((a, b) => {
-      if (a.endTime == null && b.endTime == null) {
-        return a.index - b.index
-      }
-      if (a.endTime == null) {
-        return 1
-      }
-      if (b.endTime == null) {
-        return -1
-      }
-      return a.endTime - b.endTime
-    })
-    .map((item) => item.row)
-}
-
 function useTweetMarketResolution({ event, currentTimestamp }: { event: Event; currentTimestamp: number | null }) {
   const isTweetMarketEvent = useMemo(() => isTweetMarketsEvent(event), [event])
   const xtrackerTweetCountQuery = useXTrackerTweetCount(event, isTweetMarketEvent)
@@ -583,7 +561,7 @@ function useMarketRowsByResolution({
     }))
   }, [marketRows, orderBookSummaries])
 
-  const { activeDisplayRows, sortedResolvedDisplayRows } = useMemo(() => {
+  const { activeDisplayRows, resolvedDisplayRows } = useMemo(() => {
     const activeRows: EventMarketRow[] = []
     const resolvedRows: EventMarketRow[] = []
 
@@ -596,11 +574,28 @@ function useMarketRowsByResolution({
       activeRows.push(row)
     })
 
-    return {
-      activeDisplayRows: sortMarketRowsByEndTime(activeRows),
-      sortedResolvedDisplayRows: sortMarketRowsByEndTime(resolvedRows),
-    }
+    return { activeDisplayRows: activeRows, resolvedDisplayRows: resolvedRows }
   }, [pricedMarketRows])
+
+  const sortedResolvedDisplayRows = useMemo(() => {
+    if (!resolvedDisplayRows.length) {
+      return resolvedDisplayRows
+    }
+
+    return resolvedDisplayRows
+      .map((row, index) => ({
+        row,
+        index,
+        endTime: getMarketEndTime(row.market),
+      }))
+      .sort((a, b) => {
+        if (a.endTime != null && b.endTime != null) {
+          return a.endTime - b.endTime
+        }
+        return a.index - b.index
+      })
+      .map((item) => item.row)
+  }, [resolvedDisplayRows])
 
   return { pricedMarketRows, activeDisplayRows, sortedResolvedDisplayRows }
 }
@@ -885,13 +880,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
             <OtherOutcomeRow shares={otherShares} showMarketIcon={Boolean(event.show_market_icons)} />
           </div>
         )}
-        {shouldShowActiveSection && !shouldShowResolvedSection && (
-          <div className="mr-2 mb-4 ml-4 border-b border-border lg:mx-0" />
-        )}
-
-        {shouldShowActiveSection && shouldShowResolvedSection && (
-          <hr className="mr-2 mb-4 ml-4 border-0 border-t border-border lg:mx-0" />
-        )}
+        {shouldShowActiveSection && <div className="mr-2 mb-4 ml-4 border-b border-border lg:mx-0" />}
 
         {shouldShowResolvedSection && (
           <div className="pb-4">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { Event } from '@/types'
 
 import { getMarketSeriesLabel } from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
+import { isMarketResolved } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketUtils'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -56,6 +57,37 @@ function parseAffiliateToastData(result: {
 const MENU_CLOSE_DELAY_MS = 120
 const COPY_FEEDBACK_DURATION_MS = 1600
 const SHARE_SUCCESS_FEEDBACK_DURATION_MS = 2000
+
+function getMarketEndTime(market: Event['markets'][number]) {
+  if (!market.end_time) {
+    return null
+  }
+
+  const parsed = Date.parse(market.end_time)
+  return Number.isNaN(parsed) ? null : parsed
+}
+
+function sortMarketsByEndTime(markets: Event['markets']) {
+  return markets
+    .map((market, index) => ({
+      market,
+      index,
+      endTime: getMarketEndTime(market),
+    }))
+    .sort((a, b) => {
+      if (a.endTime == null && b.endTime == null) {
+        return a.index - b.index
+      }
+      if (a.endTime == null) {
+        return 1
+      }
+      if (b.endTime == null) {
+        return -1
+      }
+      return a.endTime - b.endTime
+    })
+    .map((item) => item.market)
+}
 
 function useCopyFeedback() {
   const [copiedKey, setCopiedKey] = useState<string | null>(null)
@@ -265,6 +297,14 @@ export default function EventShare({ event }: EventShareProps) {
   const affiliateCode = user?.username?.trim() || user?.affiliate_code?.trim() || ''
   const isMultiMarket = event.total_markets_count > 1
   const eventPath = resolveEventPagePath(event)
+  const { activeMarkets, resolvedMarkets } = useMemo(() => {
+    const shareableMarkets = event.markets.filter((market) => market.slug)
+
+    return {
+      activeMarkets: sortMarketsByEndTime(shareableMarkets.filter((market) => !isMarketResolved(market))),
+      resolvedMarkets: sortMarketsByEndTime(shareableMarkets.filter((market) => isMarketResolved(market))),
+    }
+  }, [event.markets])
 
   const { copiedKey, markKeyAsCopied, markShareSuccess, shareSuccess } = useCopyFeedback()
   const {
@@ -346,6 +386,24 @@ export default function EventShare({ event }: EventShareProps) {
     }
   }
 
+  function renderMarketItem(market: Event['markets'][number]) {
+    const label = getMarketSeriesLabel(market)
+    const key = `market-${market.condition_id}`
+
+    return (
+      <DropdownMenuItem
+        key={market.condition_id}
+        closeOnClick={false}
+        onClick={() => {
+          void handleCopy(key, resolveEventMarketPath(event, market.slug))
+        }}
+        className={cn('py-2 text-sm font-semibold', copiedKey === key ? 'text-foreground' : 'text-muted-foreground')}
+      >
+        {copiedKey === key ? t('Copied!') : label}
+      </DropdownMenuItem>
+    )
+  }
+
   if (isMultiMarket) {
     return (
       <div ref={wrapperRef} onPointerEnter={handleWrapperPointerEnter} onPointerLeave={handleWrapperPointerLeave}>
@@ -379,7 +437,7 @@ export default function EventShare({ event }: EventShareProps) {
             align="end"
             sideOffset={8}
             collisionPadding={16}
-            className="max-h-80 w-48 border border-border bg-background p-0 text-foreground shadow-xl"
+            className="max-h-56 w-48 overscroll-contain border border-border bg-background p-1 text-foreground shadow-xl"
           >
             <DropdownMenuItem
               closeOnClick={false}
@@ -387,36 +445,16 @@ export default function EventShare({ event }: EventShareProps) {
                 void handleCopy('event', eventPath)
               }}
               className={cn(
-                'rounded-none px-3 py-2.5 text-sm font-semibold transition-colors first:rounded-t-md last:rounded-b-md',
+                'py-2 text-sm font-semibold',
                 copiedKey === 'event' ? 'text-foreground' : 'text-muted-foreground',
-                'hover:bg-muted/70 hover:text-foreground focus:bg-muted',
               )}
             >
               {copiedKey === 'event' ? t('Copied!') : t('Copy link')}
             </DropdownMenuItem>
-            <DropdownMenuSeparator className="my-0 bg-border" />
-            {event.markets
-              .filter((market) => market.slug)
-              .map((market) => {
-                const label = getMarketSeriesLabel(market)
-                const key = `market-${market.condition_id}`
-                return (
-                  <DropdownMenuItem
-                    key={market.condition_id}
-                    closeOnClick={false}
-                    onClick={() => {
-                      void handleCopy(key, resolveEventMarketPath(event, market.slug))
-                    }}
-                    className={cn(
-                      `rounded-none px-3 py-2.5 text-sm font-semibold transition-colors first:rounded-t-md last:rounded-b-md`,
-                      copiedKey === key ? 'text-foreground' : 'text-muted-foreground',
-                      'hover:bg-muted/70 hover:text-foreground focus:bg-muted',
-                    )}
-                  >
-                    {copiedKey === key ? t('Copied!') : label}
-                  </DropdownMenuItem>
-                )
-              })}
+            <DropdownMenuSeparator />
+            {activeMarkets.map(renderMarketItem)}
+            {activeMarkets.length > 0 && resolvedMarkets.length > 0 && <DropdownMenuSeparator />}
+            {resolvedMarkets.map(renderMarketItem)}
           </DropdownMenuContent>
         </DropdownMenu>
       </div>

--- a/tests/unit/EventShare.test.tsx
+++ b/tests/unit/EventShare.test.tsx
@@ -31,8 +31,8 @@ vi.mock('@/components/ui/dropdown-menu', () => ({
       </div>
     )
   },
-  DropdownMenuContent: function MockDropdownMenuContent({ children }: any) {
-    return <div>{children}</div>
+  DropdownMenuContent: function MockDropdownMenuContent({ children, ...props }: any) {
+    return <div {...props}>{children}</div>
   },
   DropdownMenuItem: function MockDropdownMenuItem({ children, closeOnClick: _closeOnClick, onClick, ...props }: any) {
     return (
@@ -310,6 +310,62 @@ describe('eventShare', () => {
       expect(writeText).toHaveBeenCalledWith('http://localhost:3000/event/event-1?r=abc123')
     })
     expect(screen.getByTestId('share-menu')).toHaveAttribute('data-state', 'closed')
+  })
+
+  it('groups multi-market links by resolution and sorts each group by end time', () => {
+    const event = createEvent({
+      total_markets_count: 4,
+      markets: [
+        {
+          ...createEvent().markets[0],
+          id: 'market-resolved-later',
+          slug: 'resolved-later',
+          condition_id: 'condition-resolved-later',
+          title: 'Resolved later',
+          end_time: '2026-09-06T12:00:00.000Z',
+          is_resolved: true,
+        },
+        {
+          ...createEvent().markets[0],
+          id: 'market-active-later',
+          slug: 'active-later',
+          condition_id: 'condition-active-later',
+          title: 'Active later',
+          end_time: '2026-09-05T12:00:00.000Z',
+        },
+        {
+          ...createEvent().markets[0],
+          id: 'market-active-sooner',
+          slug: 'active-sooner',
+          condition_id: 'condition-active-sooner',
+          title: 'Active sooner',
+          end_time: '2026-09-04T12:00:00.000Z',
+        },
+        {
+          ...createEvent().markets[0],
+          id: 'market-resolved-sooner',
+          slug: 'resolved-sooner',
+          condition_id: 'condition-resolved-sooner',
+          title: 'Resolved sooner',
+          end_time: '2026-09-03T12:00:00.000Z',
+          is_resolved: true,
+        },
+      ] as any,
+    })
+
+    renderWithQueryClient(<EventShare event={event} />)
+
+    fireEvent.pointerEnter(screen.getByRole('button', { name: 'Copy event link' }), { pointerType: 'mouse' })
+
+    const menuItems = screen
+      .getAllByRole('button')
+      .filter((button) => button.textContent)
+      .map((button) => button.textContent)
+
+    expect(menuItems).toEqual(['Copy link', 'Active sooner', 'Active later', 'Resolved sooner', 'Resolved later'])
+    expect(document.querySelectorAll('hr')).toHaveLength(2)
+    expect(document.querySelector('.max-h-56')).toHaveClass('p-1', 'overscroll-contain')
+    expect(screen.getByRole('button', { name: 'Active sooner' })).toHaveClass('py-2')
   })
 
   it('closes an open multi-market menu when the page scrolls', () => {

--- a/tests/unit/FilterToolbar.test.tsx
+++ b/tests/unit/FilterToolbar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 
 import type { FilterState } from '@/app/[locale]/(platform)/_providers/FilterProvider'
 
@@ -112,5 +112,40 @@ describe('filterToolbar', () => {
 
     expect(screen.queryByTestId('filter-search-input')).not.toBeInTheDocument()
     expect(document.activeElement).toBe(screen.getByTestId('filter-search-trigger'))
+  })
+
+  it('commits an emptied non-collapsible search when Escape is pressed', () => {
+    const onFiltersChange = vi.fn()
+    const filters = { ...FILTERS, search: 'bitcoin' }
+
+    render(<FilterToolbar filters={filters} onFiltersChange={onFiltersChange} />)
+
+    const searchInput = screen.getByTestId('filter-search-input')
+    fireEvent.change(searchInput, { target: { value: '' } })
+    fireEvent.keyDown(searchInput, { key: 'Escape' })
+
+    expect(searchInput).toHaveValue('')
+    expect(onFiltersChange).toHaveBeenCalledWith({ search: '' })
+  })
+
+  it('does not cancel a non-collapsible search debounce when Escape is pressed with text', async () => {
+    vi.useFakeTimers()
+    const onFiltersChange = vi.fn()
+
+    try {
+      render(<FilterToolbar filters={FILTERS} onFiltersChange={onFiltersChange} />)
+
+      const searchInput = screen.getByTestId('filter-search-input')
+      fireEvent.change(searchInput, { target: { value: 'bitcoin' } })
+      fireEvent.keyDown(searchInput, { key: 'Escape' })
+
+      expect(onFiltersChange).not.toHaveBeenCalled()
+
+      await act(() => vi.advanceTimersByTime(150))
+
+      expect(onFiltersChange).toHaveBeenCalledWith({ search: 'bitcoin' })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/tests/unit/FilterToolbar.test.tsx
+++ b/tests/unit/FilterToolbar.test.tsx
@@ -84,12 +84,16 @@ describe('filterToolbar', () => {
 
     fireEvent.pointerDown(document.body)
 
+    expect(screen.getByTestId('filter-search-input')).toBeVisible()
+
+    fireEvent.click(document.body)
+
     expect(screen.queryByTestId('filter-search-input')).not.toBeInTheDocument()
     expect(screen.getByTestId('filter-search-trigger')).toBeVisible()
     expect(document.activeElement).toBe(screen.getByTestId('filter-search-trigger'))
   })
 
-  it('keeps a typed query open when Escape is pressed before debounce completes', () => {
+  it('clears a typed query before closing the search with Escape', () => {
     const onFiltersChange = vi.fn()
 
     render(<FilterToolbar collapsibleSearch filters={FILTERS} onFiltersChange={onFiltersChange} />)
@@ -101,5 +105,12 @@ describe('filterToolbar', () => {
     fireEvent.keyDown(searchInput, { key: 'Escape' })
 
     expect(screen.getByTestId('filter-search-input')).toBeVisible()
+    expect(searchInput).toHaveValue('')
+    expect(onFiltersChange).toHaveBeenCalledWith({ search: '' })
+
+    fireEvent.keyDown(searchInput, { key: 'Escape' })
+
+    expect(screen.queryByTestId('filter-search-input')).not.toBeInTheDocument()
+    expect(document.activeElement).toBe(screen.getByTestId('filter-search-trigger'))
   })
 })


### PR DESCRIPTION
## Summary
- keep collapsible home search accessible on close, during debounce, and on mobile
- compact and align resolved/awaiting order panel states
- group multi-market copy links into active and resolved sections, sorted by end time
- cap the copy-link dropdown height with internal scrolling and match the header menu styling

## Validation
- 370 test files passed
- 1,971 tests passed
- production build passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the collapsible home search and the multi-market event share dropdown.

- Collapsible search clears a typed query on the first Escape and closes on the next; empty search still dismisses on outside click and restores focus to the search trigger.
- Non-collapsible search preserves a pending debounce when Escape is pressed with text, and commits a clear when input is empty.
- Multi-market copy links are grouped into active and resolved sections, each sorted by end time, with the menu height capped and internal scrolling.
- Simplifies the order panel active/resolved divider and tightens the copy-link menu styling.

<sup>Written for commit 274b297ccfc66dd9d22fe1be6b814631a746b854. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

