### PR TITLE
refactor: next-intl root params

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -39,7 +39,7 @@ For code contributions:
 ### Development Setup
 
 1. Fork and clone the repository
-2. Use Bun 1.4.1
+2. Use Bun 1.4.2
 3. Install dependencies: `bun install`
 4. Create a branch using the appropriate prefix, for example `feat/name-in-english` or `fix/name-in-english`
 5. Make your changes

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ jobs:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
       - run: bunx --no-install knip
       - run: bunx --no-install --bun fumadocs-mdx docs.config.ts
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
       - run: bun run test
 
@@ -48,7 +48,7 @@ jobs:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
-          bun-version: 1.4.1
+          bun-version: 1.4.2
       - run: bun install --frozen-lockfile
       - run: bun run build
 

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.4.1 AS build
+FROM oven/bun:1.4.2 AS build
 WORKDIR /app
 
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -17,7 +17,7 @@ RUN bun run build
 RUN mkdir -p /tmp/runtime-node_modules \
   && cp -aL node_modules/postgres /tmp/runtime-node_modules/postgres
 
-FROM oven/bun:1.4.1 AS runner
+FROM oven/bun:1.4.2 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     ]
   },
   "engines": {
-    "bun": "1.4.1"
+    "bun": "1.4.2"
   },
   "trustedDependencies": [
     "@sentry/cli",

--- a/src/app/[locale]/(platform)/(home)/new/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/new/page.tsx
@@ -1,9 +1,6 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
-
 import HomeInitialContent from '@/app/[locale]/(platform)/(home)/_components/HomeInitialContent'
-import { getRootLocale } from '@/i18n/root-locale'
 import { getNewPageSeoTitle } from '@/lib/platform-routing'
 
 const MAIN_TAG_SLUG = 'new' as const
@@ -13,7 +10,5 @@ export const metadata: Metadata = {
 }
 
 export default async function NewPage() {
-  setRequestLocale(await getRootLocale())
-
   return <HomeInitialContent initialTag={MAIN_TAG_SLUG} />
 }

--- a/src/app/[locale]/(platform)/(home)/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/page.tsx
@@ -1,12 +1,7 @@
-import { setRequestLocale } from 'next-intl/server'
-
 import HomeInitialContent from '@/app/[locale]/(platform)/(home)/_components/HomeInitialContent'
-import { getRootLocale } from '@/i18n/root-locale'
 
 export const instant = false
 
 export default async function HomePage() {
-  setRequestLocale(await getRootLocale())
-
   return <HomeInitialContent />
 }

--- a/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import {
@@ -8,7 +7,6 @@ import {
   DynamicHomeSubcategoryPageContent,
   generateDynamicHomeSubcategoryStaticParams,
 } from '@/app/[locale]/(platform)/_lib/dynamic-home-category-page'
-import { getRootLocale } from '@/i18n/root-locale'
 import { hasDatabaseEnv } from '@/lib/db/env'
 import { isPlatformReservedRootSlug, normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
@@ -99,8 +97,6 @@ async function renderRuntimePlatformSubcategoryPage({ slug, subcategory }: { slu
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]/[subcategory]'>): Promise<Metadata> {
   const { slug, subcategory } = await params
-  setRequestLocale(await getRootLocale())
-
   return await generatePlatformSubcategoryMetadata({
     slug,
     subcategory,
@@ -109,7 +105,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]/[
 
 export default async function PlatformSubcategoryPage({ params }: PageProps<'/[locale]/[slug]/[subcategory]'>) {
   const { slug, subcategory } = await params
-  setRequestLocale(await getRootLocale())
   const renderPage = shouldPrerenderPublicShell()
     ? renderCachedPlatformSubcategoryPage
     : renderRuntimePlatformSubcategoryPage

--- a/src/app/[locale]/(platform)/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import {
@@ -72,8 +71,6 @@ async function renderPlatformSlugPage({ slug }: { slug: string }) {
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]'>): Promise<Metadata> {
   const { slug } = await params
-  setRequestLocale(await getRootLocale())
-
   return await generatePlatformSlugMetadata({
     slug,
   })
@@ -81,8 +78,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]'>
 
 export default async function PlatformSlugPage({ params }: PageProps<'/[locale]/[slug]'>) {
   const { slug } = await params
-  setRequestLocale(await getRootLocale())
-
   return await renderPlatformSlugPage({
     slug,
   })

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -1029,6 +1029,7 @@ export default function TradingOnboardingDialogs({
       />
 
       <EmailDialog
+        key={activeModal === 'email' ? 'open' : 'closed'}
         open={activeModal === 'email'}
         onOpenChange={(open) => onModalOpenChange('email', open)}
         defaultValue={emailDefaultValue}

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -434,38 +434,9 @@ function EmailDialog({
   onSkip: () => void
 }) {
   const t = useExtracted()
-  const [email, setEmail] = useState(defaultValue)
-  const emailEditedRef = useRef(false)
-  const lastSyncedDefaultValueRef = useRef(defaultValue)
-
-  useEffect(
-    function resetEmailEditStateWhenClosed() {
-      if (!open) {
-        emailEditedRef.current = false
-      }
-    },
-    [open],
-  )
-
-  useEffect(
-    function syncEmailDefaultValue() {
-      const normalizedDefaultValue = defaultValue.trim()
-      if (!open || !normalizedDefaultValue || emailEditedRef.current) {
-        return
-      }
-
-      const previousDefaultValue = lastSyncedDefaultValueRef.current.trim()
-      setEmail((currentEmail) => {
-        const normalizedCurrentEmail = currentEmail.trim()
-        if (!normalizedCurrentEmail || normalizedCurrentEmail === previousDefaultValue) {
-          return defaultValue
-        }
-        return currentEmail
-      })
-      lastSyncedDefaultValueRef.current = defaultValue
-    },
-    [defaultValue, open],
-  )
+  const [emailDraft, setEmailDraft] = useState('')
+  const [isEmailEdited, setIsEmailEdited] = useState(false)
+  const email = isEmailEdited ? emailDraft : defaultValue
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -489,8 +460,8 @@ function EmailDialog({
         <Input
           value={email}
           onChange={(event) => {
-            emailEditedRef.current = true
-            setEmail(event.target.value)
+            setIsEmailEdited(true)
+            setEmailDraft(event.target.value)
           }}
           placeholder={t('Email address')}
           type="email"

--- a/src/app/[locale]/(platform)/activity/page.tsx
+++ b/src/app/[locale]/(platform)/activity/page.tsx
@@ -2,15 +2,12 @@
 
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import ActivityFeed from '@/app/[locale]/(platform)/activity/_components/ActivityFeed'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/activity'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   const runtimeTheme = await loadRuntimeThemeState()
@@ -22,10 +19,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/activity
   }
 }
 
-export default async function ActivityPage({ params }: PageProps<'/[locale]/activity'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function ActivityPage() {
   return (
     <main className="container py-6 md:py-8">
       <ActivityFeed />

--- a/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/layout.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/layout.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react'
 
-import { setRequestLocale } from 'next-intl/server'
-
 import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
@@ -9,14 +7,10 @@ export async function generateStaticParams() {
 }
 
 export default async function EsportsSlugPartsLayout({
-  params,
   children,
 }: {
   params: Promise<{ locale: string; sport: string; slugParts: string[] }>
   children: ReactNode
 }) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
   return <div className="pb-20 min-[1200px]:h-full min-[1200px]:min-h-0 md:pb-0">{children}</div>
 }

--- a/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SportsMenuEntry, SportsMenuLinkEntry } from '@/lib/sports-menu-types'
@@ -216,8 +215,6 @@ async function generateCachedEsportsSlugMetadata({
 }): Promise<Metadata> {
   'use cache'
 
-  setRequestLocale(await getRootLocale())
-
   if (sport === STATIC_PARAMS_PLACEHOLDER || slugParts.includes(STATIC_PARAMS_PLACEHOLDER)) {
     if (shouldBypassPublicShellPlaceholder(sport, slugParts)) {
       return {}
@@ -275,8 +272,6 @@ export async function generateMetadata({
 
 async function renderCachedEsportsSlugPage({ sport, slugParts }: { sport: string; slugParts: string[] }) {
   'use cache'
-
-  setRequestLocale(await getRootLocale())
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || slugParts.includes(STATIC_PARAMS_PLACEHOLDER)) {
     if (shouldBypassPublicShellPlaceholder(sport, slugParts)) {

--- a/src/app/[locale]/(platform)/esports/[sport]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/page.tsx
@@ -1,4 +1,3 @@
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -18,7 +17,6 @@ export async function generateStaticParams() {
 
 export default async function EsportsBySportRedirectPage({ params }: PageProps<'/[locale]/esports/[sport]'>) {
   const { locale, sport } = await params
-  setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(sport)) {
       return null

--- a/src/app/[locale]/(platform)/esports/live/page.tsx
+++ b/src/app/[locale]/(platform)/esports/live/page.tsx
@@ -1,14 +1,11 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
-import { getRootLocale } from '@/i18n/root-locale'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateMetadata(): Promise<Metadata> {
-  setRequestLocale(await getRootLocale())
-
   const t = await getExtracted()
 
   const runtimeTheme = await loadRuntimeThemeState()
@@ -24,7 +21,6 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function EsportsLivePage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return <SportsFeedPageContent sportSlug="live" sportTitle={t('Live')} pageMode="liveAndSoon" vertical="esports" />

--- a/src/app/[locale]/(platform)/esports/page.tsx
+++ b/src/app/[locale]/(platform)/esports/page.tsx
@@ -2,16 +2,14 @@
 
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import type { SupportedLocale } from '@/i18n/locales'
 
 import { redirect } from '@/i18n/navigation'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
-export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return { title: t('Esports') }
@@ -19,7 +17,6 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 
 export default async function EsportsPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
-  setRequestLocale(locale)
   const { data: landingHref } = await SportsMenuRepository.getLandingHref('esports')
 
   redirect({

--- a/src/app/[locale]/(platform)/esports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/esports/soon/page.tsx
@@ -1,19 +1,16 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
-import { getRootLocale } from '@/i18n/root-locale'
 
 export async function generateMetadata(): Promise<Metadata> {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return { title: t('Esports Upcoming') }
 }
 
 export default async function EsportsSoonPage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { cacheTag } from 'next/cache'
 import { notFound } from 'next/navigation'
 
@@ -29,7 +28,6 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps<'/[locale]/event/[slug]/[market]'>): Promise<Metadata> {
   const { slug, market } = await params
   const locale = await getRootLocale()
-  setRequestLocale(locale)
   if (slug === STATIC_PARAMS_PLACEHOLDER || market === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug, market)) {
       return {}
@@ -101,8 +99,6 @@ async function CachedEventMarketPageContent({ slug, market }: { slug: string; ma
 
 export default async function EventMarketPage({ params }: PageProps<'/[locale]/event/[slug]/[market]'>) {
   const { slug, market } = await params
-  const locale = await getRootLocale()
-  setRequestLocale(locale)
   if (slug === STATIC_PARAMS_PLACEHOLDER || market === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug, market)) {
       return null

--- a/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
@@ -6,7 +6,7 @@ import { z } from 'zod'
 
 import type { SupportedLocale } from '@/i18n/locales'
 
-import { DEFAULT_LOCALE, resolveSupportedLocale } from '@/i18n/locales'
+import { DEFAULT_LOCALE, resolveSupportedLocale, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { cacheTags } from '@/lib/cache-tags'
 import { CLOB_ORDER_TYPE, MAX_CLOB_BATCH_ORDERS, MAX_ORDER_SUBMISSION_ORDERS, ORDER_TYPE } from '@/lib/constants'
 import { OrderRepository } from '@/lib/db/queries/order'
@@ -278,6 +278,14 @@ async function mapClobErrorMessage(rawError: string | null, locale: SupportedLoc
   return t('Something went wrong while processing your order. Please try again.')
 }
 
+function resolveBatchLocale(orders: StoreOrderInput[]) {
+  const locale = orders
+    .map((order) => order.locale?.trim().toLowerCase())
+    .find((value): value is SupportedLocale => SUPPORTED_LOCALES.includes(value as SupportedLocale))
+
+  return locale ?? DEFAULT_LOCALE
+}
+
 async function readClobJsonResponsePayload(response: { text?: () => Promise<string>; json?: () => Promise<unknown> }) {
   let responseText = ''
   let payload: unknown = null
@@ -489,11 +497,13 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
     return { error: TRADING_DEPOSIT_WALLET_REQUIRED_ERROR, results: null }
   }
 
-  const locale = resolveSupportedLocale(payloads[0]?.locale)
-  function getLocalizedClobError(rawError: string | null) {
-    return mapClobErrorMessage(rawError, locale)
-  }
   const validated = StoreOrdersSchema.safeParse(payloads)
+  const batchLocale = validated.success ? resolveBatchLocale(validated.data) : DEFAULT_LOCALE
+
+  function getLocalizedClobError(rawError: string | null) {
+    return mapClobErrorMessage(rawError, batchLocale)
+  }
+
   if (!validated.success) {
     return { error: await getLocalizedClobError(null), results: null }
   }
@@ -507,16 +517,17 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
   const preparedOrders: Array<{ data: StoreOrderInput; clobOrderType: ClobOrderType }> = []
 
   for (const data of validated.data) {
+    const locale = resolveSupportedLocale(data.locale)
     const maker = normalizeAddress(data.maker)
     const signer = normalizeAddress(data.signer)
     if (!maker || !signer) {
-      return { error: await getLocalizedClobError(null), results: null }
+      return { error: await mapClobErrorMessage(null, locale), results: null }
     }
     if (data.signature_type !== 3) {
-      return { error: await getLocalizedClobError(null), results: null }
+      return { error: await mapClobErrorMessage(null, locale), results: null }
     }
     if (maker.toLowerCase() !== expectedMaker.toLowerCase() || signer.toLowerCase() !== expectedMaker.toLowerCase()) {
-      return { error: await getLocalizedClobError(null), results: null }
+      return { error: await mapClobErrorMessage(null, locale), results: null }
     }
 
     const clobOrderType =
@@ -588,45 +599,60 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
             getStringField(responsePayload, 'error') ??
             getStringField(responsePayload, 'errorMsg') ??
             getStringField(responsePayload, 'message')
-          const humanMessage = await getLocalizedClobError(responseError)
           console.error(
             'Failed to send order batch to CLOB.',
             `Status ${response.status} (${response.statusText})`,
             responseError ?? responseText,
           )
-          batchFailureError ??= humanMessage
-          results.push(...preparedBatch.map(() => ({ error: humanMessage, orderId: null })))
+          const batchResults = await Promise.all(
+            preparedBatch.map(async ({ data }) => ({
+              error: await mapClobErrorMessage(responseError, resolveSupportedLocale(data.locale)),
+              orderId: null,
+            })),
+          )
+          batchFailureError ??= batchResults[0]?.error ?? (await getLocalizedClobError(responseError))
+          results.push(...batchResults)
           continue
         }
 
         if (!Array.isArray(payload) || payload.length !== preparedBatch.length) {
           console.error('CLOB batch response did not match the submitted order count.', payload)
-          const humanMessage = await getLocalizedClobError(null)
-          batchFailureError ??= humanMessage
-          results.push(...preparedBatch.map(() => ({ error: humanMessage, orderId: null })))
+          const batchResults = await Promise.all(
+            preparedBatch.map(async ({ data }) => ({
+              error: await mapClobErrorMessage(null, resolveSupportedLocale(data.locale)),
+              orderId: null,
+            })),
+          )
+          batchFailureError ??= batchResults[0]?.error ?? (await getLocalizedClobError(null))
+          results.push(...batchResults)
           continue
         }
 
         processedBatchCount += 1
         const batchResults = await Promise.all(
           payload.map(async (rawResult, index) => {
-            if (!isRecord(rawResult)) {
+            const prepared = preparedBatch[index]
+            if (!prepared) {
               return { error: await getLocalizedClobError(null), orderId: null }
+            }
+
+            const locale = resolveSupportedLocale(prepared.data.locale)
+            if (!isRecord(rawResult)) {
+              return { error: await mapClobErrorMessage(null, locale), orderId: null }
             }
             if (rawResult.success === false) {
               const responseError =
                 getStringField(rawResult, 'errorMsg') ??
                 getStringField(rawResult, 'error') ??
                 getStringField(rawResult, 'message')
-              return { error: await getLocalizedClobError(responseError), orderId: null }
+              return { error: await mapClobErrorMessage(responseError, locale), orderId: null }
             }
 
             const orderId = getStringField(rawResult, 'orderID') ?? getStringField(rawResult, 'orderId')
             if (!orderId) {
-              return { error: await getLocalizedClobError(null), orderId: null }
+              return { error: await mapClobErrorMessage(null, locale), orderId: null }
             }
 
-            const prepared = preparedBatch[index]
             try {
               const { locale: _locale, ...orderData } = prepared.data
               await OrderRepository.createOrder({
@@ -654,9 +680,14 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
         results.push(...batchResults)
       } catch (error) {
         console.error('Failed to create order batch.', error)
-        const humanMessage = await getLocalizedClobError(null)
-        batchFailureError ??= humanMessage
-        results.push(...preparedBatch.map(() => ({ error: humanMessage, orderId: null })))
+        const batchResults = await Promise.all(
+          preparedBatch.map(async ({ data }) => ({
+            error: await mapClobErrorMessage(null, resolveSupportedLocale(data.locale)),
+            orderId: null,
+          })),
+        )
+        batchFailureError ??= batchResults[0]?.error ?? (await getLocalizedClobError(null))
+        results.push(...batchResults)
       }
     }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
@@ -278,9 +278,15 @@ async function mapClobErrorMessage(rawError: string | null, locale: SupportedLoc
   return t('Something went wrong while processing your order. Please try again.')
 }
 
-function resolveBatchLocale(orders: StoreOrderInput[]) {
-  const locale = orders
-    .map((order) => order.locale?.trim().toLowerCase())
+function resolveBatchLocale(payloads: unknown) {
+  if (!Array.isArray(payloads)) {
+    return DEFAULT_LOCALE
+  }
+
+  const locale = payloads
+    .map((payload) =>
+      isRecord(payload) && typeof payload.locale === 'string' ? payload.locale.trim().toLowerCase() : null,
+    )
     .find((value): value is SupportedLocale => SUPPORTED_LOCALES.includes(value as SupportedLocale))
 
   return locale ?? DEFAULT_LOCALE
@@ -498,7 +504,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
   }
 
   const validated = StoreOrdersSchema.safeParse(payloads)
-  const batchLocale = validated.success ? resolveBatchLocale(validated.data) : DEFAULT_LOCALE
+  const batchLocale = resolveBatchLocale(payloads)
 
   function getLocalizedClobError(rawError: string | null) {
     return mapClobErrorMessage(rawError, batchLocale)
@@ -610,7 +616,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
               orderId: null,
             })),
           )
-          batchFailureError ??= batchResults[0]?.error ?? (await getLocalizedClobError(responseError))
+          batchFailureError ??= batchResults[0]!.error
           results.push(...batchResults)
           continue
         }
@@ -623,7 +629,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
               orderId: null,
             })),
           )
-          batchFailureError ??= batchResults[0]?.error ?? (await getLocalizedClobError(null))
+          batchFailureError ??= batchResults[0]!.error
           results.push(...batchResults)
           continue
         }
@@ -686,7 +692,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
             orderId: null,
           })),
         )
-        batchFailureError ??= batchResults[0]?.error ?? (await getLocalizedClobError(null))
+        batchFailureError ??= batchResults[0]!.error
         results.push(...batchResults)
       }
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
@@ -4,6 +4,9 @@ import { getExtracted } from 'next-intl/server'
 import { updateTag } from 'next/cache'
 import { z } from 'zod'
 
+import type { SupportedLocale } from '@/i18n/locales'
+
+import { DEFAULT_LOCALE, resolveSupportedLocale } from '@/i18n/locales'
 import { cacheTags } from '@/lib/cache-tags'
 import { CLOB_ORDER_TYPE, MAX_CLOB_BATCH_ORDERS, MAX_ORDER_SUBMISSION_ORDERS, ORDER_TYPE } from '@/lib/constants'
 import { OrderRepository } from '@/lib/db/queries/order'
@@ -44,6 +47,7 @@ const StoreOrderSchema = z.object({
   post_only: z.boolean().optional(),
   condition_id: z.string(),
   slug: z.string(),
+  locale: z.string().optional(),
 })
 const StoreOrdersSchema = z.array(StoreOrderSchema).min(1).max(MAX_ORDER_SUBMISSION_ORDERS)
 
@@ -204,9 +208,9 @@ function mapClobErrorMessageKey(rawError: string | null): ClobErrorMessageKey {
   return 'default'
 }
 
-async function mapClobErrorMessage(rawError: string | null) {
+async function mapClobErrorMessage(rawError: string | null, locale: SupportedLocale = DEFAULT_LOCALE) {
   const messageKey = mapClobErrorMessageKey(rawError)
-  const t = await getExtracted()
+  const t = await getExtracted({ locale })
 
   switch (messageKey) {
     case 'conditionPaused':
@@ -335,6 +339,11 @@ export async function storeOrderAction(payload: StoreOrderInput) {
     }
   }
 
+  const locale = resolveSupportedLocale(validated.data.locale)
+  function getLocalizedClobError(rawError: string | null) {
+    return mapClobErrorMessage(rawError, locale)
+  }
+
   const defaultMarketOrderType = user.settings?.trading?.market_order_type ?? CLOB_ORDER_TYPE.FAK
   const clobOrderType =
     validated.data.clob_type ??
@@ -408,7 +417,7 @@ export async function storeOrderAction(payload: StoreOrderInput) {
         getStringField(clobStoreOrderResponseJson, 'error') ??
         getStringField(clobStoreOrderResponseJson, 'errorMsg') ??
         getStringField(clobStoreOrderResponseJson, 'message')
-      const humanMessage = await mapClobErrorMessage(responseError)
+      const humanMessage = await getLocalizedClobError(responseError)
       const message = `Status ${clobStoreOrderResponse.status} (${clobStoreOrderResponse.statusText})`
       console.error('Failed to send order to CLOB.', message, responseError ?? responseText)
       return { error: humanMessage }
@@ -416,7 +425,7 @@ export async function storeOrderAction(payload: StoreOrderInput) {
 
     if (!clobStoreOrderResponseJson) {
       console.error('Failed to send order to CLOB. Empty or invalid response payload.')
-      return { error: await mapClobErrorMessage(null) }
+      return { error: await getLocalizedClobError(null) }
     }
 
     if (clobStoreOrderResponseJson?.success === false) {
@@ -424,19 +433,20 @@ export async function storeOrderAction(payload: StoreOrderInput) {
         getStringField(clobStoreOrderResponseJson, 'errorMsg') ??
         getStringField(clobStoreOrderResponseJson, 'error') ??
         getStringField(clobStoreOrderResponseJson, 'message')
-      return { error: await mapClobErrorMessage(responseError) }
+      return { error: await getLocalizedClobError(responseError) }
     }
 
     const clobOrderId =
       getStringField(clobStoreOrderResponseJson, 'orderID') ?? getStringField(clobStoreOrderResponseJson, 'orderId')
     if (!clobOrderId) {
       console.error('CLOB response did not include an order id.', clobStoreOrderResponseJson)
-      return { error: await mapClobErrorMessage(null) }
+      return { error: await getLocalizedClobError(null) }
     }
 
+    const { locale: _locale, ...orderData } = validated.data
     void OrderRepository.createOrder({
-      ...validated.data,
-      salt: BigInt(validated.data.salt),
+      ...orderData,
+      salt: BigInt(orderData.salt),
       maker_amount: BigInt(validated.data.maker_amount),
       taker_amount: BigInt(validated.data.taker_amount),
       nonce: BigInt(validated.data.nonce),
@@ -457,7 +467,7 @@ export async function storeOrderAction(payload: StoreOrderInput) {
     }
   } catch (error) {
     console.error('Failed to create order.', error)
-    return { error: await mapClobErrorMessage(null) }
+    return { error: await getLocalizedClobError(null) }
   }
 }
 
@@ -479,14 +489,18 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
     return { error: TRADING_DEPOSIT_WALLET_REQUIRED_ERROR, results: null }
   }
 
+  const locale = resolveSupportedLocale(payloads[0]?.locale)
+  function getLocalizedClobError(rawError: string | null) {
+    return mapClobErrorMessage(rawError, locale)
+  }
   const validated = StoreOrdersSchema.safeParse(payloads)
   if (!validated.success) {
-    return { error: await mapClobErrorMessage(null), results: null }
+    return { error: await getLocalizedClobError(null), results: null }
   }
 
   const expectedMaker = normalizeAddress(user.deposit_wallet_address)
   if (!expectedMaker) {
-    return { error: await mapClobErrorMessage(null), results: null }
+    return { error: await getLocalizedClobError(null), results: null }
   }
 
   const defaultMarketOrderType = user.settings?.trading?.market_order_type ?? CLOB_ORDER_TYPE.FAK
@@ -496,13 +510,13 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
     const maker = normalizeAddress(data.maker)
     const signer = normalizeAddress(data.signer)
     if (!maker || !signer) {
-      return { error: await mapClobErrorMessage(null), results: null }
+      return { error: await getLocalizedClobError(null), results: null }
     }
     if (data.signature_type !== 3) {
-      return { error: await mapClobErrorMessage(null), results: null }
+      return { error: await getLocalizedClobError(null), results: null }
     }
     if (maker.toLowerCase() !== expectedMaker.toLowerCase() || signer.toLowerCase() !== expectedMaker.toLowerCase()) {
-      return { error: await mapClobErrorMessage(null), results: null }
+      return { error: await getLocalizedClobError(null), results: null }
     }
 
     const clobOrderType =
@@ -574,7 +588,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
             getStringField(responsePayload, 'error') ??
             getStringField(responsePayload, 'errorMsg') ??
             getStringField(responsePayload, 'message')
-          const humanMessage = await mapClobErrorMessage(responseError)
+          const humanMessage = await getLocalizedClobError(responseError)
           console.error(
             'Failed to send order batch to CLOB.',
             `Status ${response.status} (${response.statusText})`,
@@ -587,7 +601,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
 
         if (!Array.isArray(payload) || payload.length !== preparedBatch.length) {
           console.error('CLOB batch response did not match the submitted order count.', payload)
-          const humanMessage = await mapClobErrorMessage(null)
+          const humanMessage = await getLocalizedClobError(null)
           batchFailureError ??= humanMessage
           results.push(...preparedBatch.map(() => ({ error: humanMessage, orderId: null })))
           continue
@@ -597,31 +611,32 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
         const batchResults = await Promise.all(
           payload.map(async (rawResult, index) => {
             if (!isRecord(rawResult)) {
-              return { error: await mapClobErrorMessage(null), orderId: null }
+              return { error: await getLocalizedClobError(null), orderId: null }
             }
             if (rawResult.success === false) {
               const responseError =
                 getStringField(rawResult, 'errorMsg') ??
                 getStringField(rawResult, 'error') ??
                 getStringField(rawResult, 'message')
-              return { error: await mapClobErrorMessage(responseError), orderId: null }
+              return { error: await getLocalizedClobError(responseError), orderId: null }
             }
 
             const orderId = getStringField(rawResult, 'orderID') ?? getStringField(rawResult, 'orderId')
             if (!orderId) {
-              return { error: await mapClobErrorMessage(null), orderId: null }
+              return { error: await getLocalizedClobError(null), orderId: null }
             }
 
             const prepared = preparedBatch[index]
             try {
+              const { locale: _locale, ...orderData } = prepared.data
               await OrderRepository.createOrder({
-                ...prepared.data,
-                salt: BigInt(prepared.data.salt),
-                maker_amount: BigInt(prepared.data.maker_amount),
-                taker_amount: BigInt(prepared.data.taker_amount),
-                nonce: BigInt(prepared.data.nonce),
-                fee_rate_bps: Number(prepared.data.fee_rate_bps),
-                expiration: BigInt(prepared.data.expiration),
+                ...orderData,
+                salt: BigInt(orderData.salt),
+                maker_amount: BigInt(orderData.maker_amount),
+                taker_amount: BigInt(orderData.taker_amount),
+                nonce: BigInt(orderData.nonce),
+                fee_rate_bps: Number(orderData.fee_rate_bps),
+                expiration: BigInt(orderData.expiration),
                 user_id: user.id,
                 affiliate_user_id: user.referred_by_user_id,
                 type: prepared.clobOrderType,
@@ -639,7 +654,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
         results.push(...batchResults)
       } catch (error) {
         console.error('Failed to create order batch.', error)
-        const humanMessage = await mapClobErrorMessage(null)
+        const humanMessage = await getLocalizedClobError(null)
         batchFailureError ??= humanMessage
         results.push(...preparedBatch.map(() => ({ error: humanMessage, orderId: null })))
       }
@@ -647,7 +662,7 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
 
     if (processedBatchCount === 0) {
       return {
-        error: batchFailureError ?? (await mapClobErrorMessage(null)),
+        error: batchFailureError ?? (await getLocalizedClobError(null)),
         results: null,
       }
     }
@@ -658,6 +673,6 @@ export async function storeOrdersAction(payloads: StoreOrderInput[]) {
     return { error: null, results }
   } catch (error) {
     console.error('Failed to create order batch.', error)
-    return { error: await mapClobErrorMessage(null), results: null }
+    return { error: await getLocalizedClobError(null), results: null }
   }
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -1556,6 +1556,7 @@ export default function EventOrderPanelForm({
         clobOrderType: state.type === ORDER_TYPE.LIMIT && hasExpirationLimit ? CLOB_ORDER_TYPE.GTD : undefined,
         conditionId: activeMarket.condition_id,
         slug: event.slug,
+        locale,
       })
 
       if (result?.error) {
@@ -2018,6 +2019,7 @@ export default function EventOrderPanelForm({
           clobOrderType: CLOB_ORDER_TYPE.FOK,
           conditionId: activeMarket.condition_id,
           slug: event.slug,
+          locale,
         }),
         preparedPolymarketOrder.post(),
       ])

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventProvideLiquidityDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventProvideLiquidityDialog.tsx
@@ -4,7 +4,7 @@ import type { InfiniteData } from '@tanstack/react-query'
 
 import { useQueryClient } from '@tanstack/react-query'
 import { BotIcon, TriangleAlertIcon } from 'lucide-react'
-import { useExtracted } from 'next-intl'
+import { useExtracted, useLocale } from 'next-intl'
 import { useMemo, useState } from 'react'
 import { useSignTypedData } from 'wagmi'
 
@@ -105,6 +105,7 @@ export default function EventProvideLiquidityDialog({
   onSuccess,
 }: EventProvideLiquidityDialogProps) {
   const t = useExtracted()
+  const locale = useLocale()
   const queryClient = useQueryClient()
   const user = useUser()
   const { open: openAppKit } = useAppKit()
@@ -269,6 +270,7 @@ export default function EventProvideLiquidityDialog({
           postOnly: true,
           conditionId: market.condition_id,
           slug: eventSlug,
+          locale,
         })
         setSignatureProgress(signatureNumber)
       }

--- a/src/app/[locale]/(platform)/event/[slug]/layout.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/layout.tsx
@@ -1,15 +1,10 @@
-import { setRequestLocale } from 'next-intl/server'
-
 import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
   return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
-export default async function EventLayout({ params, children }: LayoutProps<'/[locale]/event/[slug]'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function EventLayout({ children }: LayoutProps<'/[locale]/event/[slug]'>) {
   return (
     <main className="container grid min-h-screen gap-8 pb-12 lg:grid-cols-[minmax(0,3fr)_21.25rem]">{children}</main>
   )

--- a/src/app/[locale]/(platform)/event/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { cacheTag } from 'next/cache'
 import { notFound } from 'next/navigation'
 
@@ -29,7 +28,6 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps<'/[locale]/event/[slug]'>): Promise<Metadata> {
   const { slug } = await params
   const locale = await getRootLocale()
-  setRequestLocale(locale)
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug)) {
       return {}
@@ -97,8 +95,6 @@ async function CachedEventPageContent({ slug }: { slug: string }) {
 
 export default async function EventPage({ params }: PageProps<'/[locale]/event/[slug]'>) {
   const { slug } = await params
-  const locale = await getRootLocale()
-  setRequestLocale(locale)
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug)) {
       return null

--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from 'react'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import { PlatformLayoutFooter } from '@/app/[locale]/(platform)/(home)/_components/PlatformFooter'
 import AffiliateQueryHandler from '@/app/[locale]/(platform)/_components/AffiliateQueryHandler'
@@ -61,10 +61,7 @@ async function PlatformLayoutContent({ children }: { children: ReactNode }) {
 }
 
 export default async function PlatformLayout({ children }: LayoutProps<'/[locale]'>) {
-  const resolvedLocale = await getRootLocale()
   const wagmiCookie = shouldPrerenderPublicShell() ? null : await getWagmiStateCookieValue()
-  setRequestLocale(resolvedLocale)
-
   return (
     <AppKitProvider wagmiCookie={wagmiCookie}>
       <CommunityFollowsProvider>

--- a/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { Suspense } from 'react'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -64,8 +64,6 @@ export async function generateMetadata({
 
   const { filters } = await params
   const locale = await getRootLocale()
-  setRequestLocale(locale)
-
   const t = await getExtracted()
 
   const runtimeTheme = await loadRuntimeThemeState()
@@ -147,8 +145,6 @@ async function LeaderboardPageWithParams({
 
 async function LeaderboardPageContent({ filters }: { filters?: string[] }) {
   'use cache'
-
-  setRequestLocale(await getRootLocale())
 
   const initialFilters = parseLeaderboardFilters(filters)
 

--- a/src/app/[locale]/(platform)/mentions/page.tsx
+++ b/src/app/[locale]/(platform)/mentions/page.tsx
@@ -2,7 +2,7 @@
 
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { cacheTag } from 'next/cache'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -11,10 +11,7 @@ import MentionsList from '@/app/[locale]/(platform)/mentions/_components/Mention
 import { cacheTags } from '@/lib/cache-tags'
 import { EventRepository } from '@/lib/db/queries/event'
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/mentions'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -25,7 +22,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/mentions
 
 export default async function MentionsPage({ params }: PageProps<'/[locale]/mentions'>) {
   const { locale } = await params
-  setRequestLocale(locale)
   const t = await getExtracted()
   cacheTag(cacheTags.eventsList)
   const resolvedLocale = locale as SupportedLocale

--- a/src/app/[locale]/(platform)/portfolio/layout.tsx
+++ b/src/app/[locale]/(platform)/portfolio/layout.tsx
@@ -1,9 +1,4 @@
-import { setRequestLocale } from 'next-intl/server'
-
-export default async function PortfolioLayout({ params, children }: LayoutProps<'/[locale]/portfolio'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function PortfolioLayout({ children }: LayoutProps<'/[locale]/portfolio'>) {
   return (
     <main className="container py-8">
       <div className="mx-auto grid max-w-5xl gap-6">{children}</div>

--- a/src/app/[locale]/(platform)/portfolio/page.tsx
+++ b/src/app/[locale]/(platform)/portfolio/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import PortfolioMarketsWonCard from '@/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCard'
 import PortfolioTabs from '@/app/[locale]/(platform)/portfolio/_components/PortfolioTabs'
@@ -9,9 +9,7 @@ import PublicProfileHeroCards from '@/app/[locale]/(platform)/profile/_component
 import { UserRepository } from '@/lib/db/queries/user'
 import { fetchPortfolioSnapshot } from '@/lib/portfolio'
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/portfolio'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return { title: t('Portfolio') }
@@ -21,9 +19,7 @@ function getFallbackChartEndDate() {
   return new Date().toISOString()
 }
 
-export default async function PortfolioPage({ params }: PageProps<'/[locale]/portfolio'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function PortfolioPage() {
   const t = await getExtracted()
 
   const user = await UserRepository.getCurrentUser()

--- a/src/app/[locale]/(platform)/predictions/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -25,8 +24,6 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps<'/[locale]/predictions/[slug]'>): Promise<Metadata> {
   const { locale, slug } = await params
   const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
-
   if (shouldBypassPublicShellPlaceholder(slug)) {
     return {}
   }
@@ -46,8 +43,6 @@ export default async function PredictionResultsPage({
     searchParams.then(resolvePredictionResultsFiltersFromSearchParams),
   ])
   const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
-
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug)) {
       return null

--- a/src/app/[locale]/(platform)/predictions/page.tsx
+++ b/src/app/[locale]/(platform)/predictions/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import type { SupportedLocale } from '@/i18n/locales'
 
@@ -24,7 +24,6 @@ async function getPopularPredictionsCopy(locale: SupportedLocale) {
 export async function generateMetadata({ params }: PageProps<'/[locale]/predictions'>): Promise<Metadata> {
   const { locale } = await params
   const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
   const copy = await getPopularPredictionsCopy(resolvedLocale)
 
   return generatePredictionResultsMetadata({
@@ -42,7 +41,6 @@ export default async function PopularPredictionsPage({ params, searchParams }: P
     searchParams.then(resolvePredictionResultsFiltersFromSearchParams),
   ])
   const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
   const copy = await getPopularPredictionsCopy(resolvedLocale)
 
   return renderPredictionResultsPage({

--- a/src/app/[locale]/(platform)/profile/[slug]/layout.tsx
+++ b/src/app/[locale]/(platform)/profile/[slug]/layout.tsx
@@ -1,12 +1,9 @@
-import { setRequestLocale } from 'next-intl/server'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
 import Loading from './loading'
 
-async function PublicProfileLayoutContent({ params, children }: LayoutProps<'/[locale]/profile/[slug]'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+async function PublicProfileLayoutContent({ children }: LayoutProps<'/[locale]/profile/[slug]'>) {
   await connection()
 
   return children

--- a/src/app/[locale]/(platform)/profile/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/profile/[slug]/page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -31,8 +30,6 @@ function resolveProfileNamespaceSlug(slug: string) {
 export async function generateMetadata({ params }: PageProps<'/[locale]/profile/[slug]'>): Promise<Metadata> {
   const { locale, slug } = await params
   const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
-
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug)) {
       return {}
@@ -47,8 +44,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/profile/
 }
 
 export default async function ProfileSlugPage({ params }: PageProps<'/[locale]/profile/[slug]'>) {
-  const { locale, slug } = await params
-  setRequestLocale(locale)
+  const { slug } = await params
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug)) {
       return null

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
@@ -4,7 +4,7 @@ import type { InfiniteData, QueryClient } from '@tanstack/react-query'
 
 import { useAppKitAccount } from '@reown/appkit/react'
 import { useQueryClient } from '@tanstack/react-query'
-import { useExtracted } from 'next-intl'
+import { useExtracted, useLocale } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useSignTypedData } from 'wagmi'
@@ -372,6 +372,7 @@ function useSellPositionFlow({
   signTypedDataAsync,
   resolveOutcomeIndex,
   translate,
+  locale,
 }: {
   clobUrl: string
   userAddress: string
@@ -387,6 +388,7 @@ function useSellPositionFlow({
   signTypedDataAsync: ReturnType<typeof useSignTypedData>['signTypedDataAsync']
   resolveOutcomeIndex: (position: PublicPosition) => number
   translate: (message: string, values?: Record<string, string | number | Date>) => string
+  locale: string
 }) {
   const [sellModalPayload, setSellModalPayload] = useState<SellModalPayload | null>(null)
   const [isCashOutSubmitting, setIsCashOutSubmitting] = useState(false)
@@ -637,6 +639,7 @@ function useSellPositionFlow({
           orderType: ORDER_TYPE.MARKET,
           conditionId,
           slug: eventSlug,
+          locale,
         })
 
         if (result?.error) {
@@ -723,6 +726,7 @@ function useSellPositionFlow({
       sellModalPayload,
       signTypedDataAsync,
       translate,
+      locale,
       user,
       userAddress,
     ],
@@ -739,6 +743,7 @@ function useSellPositionFlow({
 
 export default function PublicPositionsList({ userAddress }: PublicPositionsListProps) {
   const t = useExtracted()
+  const locale = useLocale()
   const translateFeedback = useOrderFeedbackTranslate()
   const queryClient = useQueryClient()
   const router = useRouter()
@@ -824,6 +829,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
       signTypedDataAsync,
       resolveOutcomeIndex,
       translate: translateFeedback,
+      locale,
     })
 
   useScrollToTopOnFilterChange({

--- a/src/app/[locale]/(platform)/series/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/series/[slug]/page.tsx
@@ -1,4 +1,3 @@
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -82,7 +81,6 @@ interface SeriesPageProps {
 
 export default async function SeriesPage({ params }: SeriesPageProps) {
   const { locale, slug } = await params
-  setRequestLocale(locale)
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug)) {

--- a/src/app/[locale]/(platform)/settings/account/page.tsx
+++ b/src/app/[locale]/(platform)/settings/account/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import SettingsDeleteAccountContent from '@/app/[locale]/(platform)/settings/_components/SettingsDeleteAccountContent'
@@ -9,9 +9,7 @@ import { UserRepository } from '@/lib/db/queries/user'
 
 export const instant = false
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/settings/account'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -19,10 +17,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/settings
   }
 }
 
-export default async function AccountSettingsPage({ params }: PageProps<'/[locale]/settings/account'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function AccountSettingsPage() {
   const t = await getExtracted()
 
   const user = await UserRepository.getCurrentUser({ disableCookieCache: true, minimal: true })

--- a/src/app/[locale]/(platform)/settings/affiliate/page.tsx
+++ b/src/app/[locale]/(platform)/settings/affiliate/page.tsx
@@ -1,12 +1,8 @@
-import { setRequestLocale } from 'next-intl/server'
-
 import type { SupportedLocale } from '@/i18n/locales'
 
 import { redirect } from '@/i18n/navigation'
 
 export default async function AffiliateSettingsRedirect({ params }: PageProps<'/[locale]/settings/affiliate'>) {
   const { locale } = await params
-  setRequestLocale(locale)
-
   redirect({ href: '/settings/rewards', locale: locale as SupportedLocale })
 }

--- a/src/app/[locale]/(platform)/settings/layout.tsx
+++ b/src/app/[locale]/(platform)/settings/layout.tsx
@@ -1,11 +1,8 @@
-import { setRequestLocale } from 'next-intl/server'
 import { connection } from 'next/server'
 
 import SettingsSidebar from '@/app/[locale]/(platform)/settings/_components/SettingsSidebar'
 
-export default async function SettingsLayout({ params, children }: LayoutProps<'/[locale]/settings'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function SettingsLayout({ children }: LayoutProps<'/[locale]/settings'>) {
   await connection()
 
   return (

--- a/src/app/[locale]/(platform)/settings/notifications/page.tsx
+++ b/src/app/[locale]/(platform)/settings/notifications/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import SettingsNotificationsContent from '@/app/[locale]/(platform)/settings/_components/SettingsNotificationsContent'
@@ -8,9 +8,7 @@ import { UserRepository } from '@/lib/db/queries/user'
 
 export const instant = false
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/settings/notifications'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -18,10 +16,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/settings
   }
 }
 
-export default async function NotificationsSettingsPage({ params }: PageProps<'/[locale]/settings/notifications'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function NotificationsSettingsPage() {
   const t = await getExtracted()
 
   const user = await UserRepository.getCurrentUser({ disableCookieCache: true, minimal: true })

--- a/src/app/[locale]/(platform)/settings/page.tsx
+++ b/src/app/[locale]/(platform)/settings/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import SettingsProfilePanel from '@/app/[locale]/(platform)/settings/_components/SettingsProfilePanel'
@@ -8,9 +8,7 @@ import { UserRepository } from '@/lib/db/queries/user'
 
 export const instant = false
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/settings'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -18,10 +16,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/settings
   }
 }
 
-export default async function SettingsPage({ params }: PageProps<'/[locale]/settings'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function SettingsPage() {
   const t = await getExtracted()
 
   const user = await UserRepository.getCurrentUser({ disableCookieCache: true })

--- a/src/app/[locale]/(platform)/settings/rewards/page.tsx
+++ b/src/app/[locale]/(platform)/settings/rewards/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -73,9 +73,7 @@ function buildResolutionRewardSeries(
   })
 }
 
-export async function generateMetadata({ params }: RewardsSettingsPageProps): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -85,7 +83,6 @@ export async function generateMetadata({ params }: RewardsSettingsPageProps): Pr
 
 export default async function RewardsSettingsPage({ params }: RewardsSettingsPageProps) {
   const { locale } = await params
-  setRequestLocale(locale)
   const resolvedLocale = SUPPORTED_LOCALES.includes(locale as SupportedLocale)
     ? (locale as SupportedLocale)
     : DEFAULT_LOCALE

--- a/src/app/[locale]/(platform)/settings/sdks/page.tsx
+++ b/src/app/[locale]/(platform)/settings/sdks/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 
 import { ArrowRightIcon, BookOpenIcon } from 'lucide-react'
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import { isAddress, zeroAddress } from 'viem'
 
@@ -21,9 +21,7 @@ import { cn } from '@/lib/utils'
 
 export const instant = false
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/settings/sdks'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -31,10 +29,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/settings
   }
 }
 
-export default async function SdkDownloadsSettingsPage({ params }: PageProps<'/[locale]/settings/sdks'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function SdkDownloadsSettingsPage() {
   const t = await getExtracted()
 
   const user = await UserRepository.getCurrentUser({ disableCookieCache: true, minimal: true })

--- a/src/app/[locale]/(platform)/settings/trading/page.tsx
+++ b/src/app/[locale]/(platform)/settings/trading/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import SettingsTradingContent from '@/app/[locale]/(platform)/settings/_components/SettingsTradingContent'
@@ -8,9 +8,7 @@ import { UserRepository } from '@/lib/db/queries/user'
 
 export const instant = false
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/settings/trading'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return {
@@ -18,10 +16,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/settings
   }
 }
 
-export default async function TradingSettingsPage({ params }: PageProps<'/[locale]/settings/trading'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function TradingSettingsPage() {
   const t = await getExtracted()
 
   const user = await UserRepository.getCurrentUser({ disableCookieCache: true, minimal: true })

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/layout.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/layout.tsx
@@ -1,7 +1,5 @@
 import type { ReactNode } from 'react'
 
-import { setRequestLocale } from 'next-intl/server'
-
 import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const instant = false
@@ -10,15 +8,6 @@ export async function generateStaticParams() {
   return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER })
 }
 
-export default async function SportsEventLayout({
-  params,
-  children,
-}: {
-  params: Promise<{ locale: string; sport: string; event: string }>
-  children: ReactNode
-}) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function SportsEventLayout({ children }: { children: ReactNode }) {
   return <div className="pb-20 min-[1200px]:h-full min-[1200px]:min-h-0 md:pb-0">{children}</div>
 }

--- a/src/app/[locale]/(platform)/sports/[sport]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/page.tsx
@@ -1,4 +1,3 @@
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -18,7 +17,6 @@ export async function generateStaticParams() {
 
 export default async function SportsBySportRedirectPage({ params }: PageProps<'/[locale]/sports/[sport]'>) {
   const { locale, sport } = await params
-  setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(sport)) {
       return null

--- a/src/app/[locale]/(platform)/sports/_utils/sports-event-page.tsx
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-event-page.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SportsVertical } from '@/lib/sports-vertical'
@@ -94,7 +93,6 @@ export async function generateSportsVerticalEventMetadata({
   event,
 }: SportsVerticalEventPageParams): Promise<Metadata> {
   const locale = await getRootLocale()
-  setRequestLocale(locale)
 
   if (shouldBypassPublicShellPlaceholder(sport, league, event)) {
     return {}
@@ -194,7 +192,6 @@ export async function generateSportsVerticalEventMarketMetadata({
   market,
 }: SportsVerticalEventMarketPageParams): Promise<Metadata> {
   const locale = await getRootLocale()
-  setRequestLocale(locale)
 
   if (shouldBypassPublicShellPlaceholder(sport, league, event, market)) {
     return {}

--- a/src/app/[locale]/(platform)/sports/_utils/sports-section-page.tsx
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-section-page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SportsVertical } from '@/lib/sports-vertical'
@@ -77,9 +77,6 @@ export async function generateSportsVerticalSectionMetadata({
   section,
   week,
 }: SportsVerticalSectionPageParams): Promise<Metadata> {
-  const locale = await getRootLocale()
-  setRequestLocale(locale)
-
   if (!assertValidSportsSectionParams({ sport, week })) {
     return {}
   }
@@ -146,7 +143,6 @@ export async function renderSportsVerticalSectionPage({
   week,
 }: SportsVerticalSectionPageParams) {
   const locale = await getRootLocale()
-  setRequestLocale(locale)
 
   if (!assertValidSportsSectionParams({ sport, week })) {
     return null

--- a/src/app/[locale]/(platform)/sports/futures/[sportSlug]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/futures/[sportSlug]/page.tsx
@@ -2,12 +2,10 @@
 
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import SportsContent from '@/app/[locale]/(platform)/sports/_components/SportsContent'
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
-import { getRootLocale } from '@/i18n/root-locale'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 import {
   getPublicShellStaticParams,
@@ -25,7 +23,6 @@ export const metadata: Metadata = {
 
 export default async function SportsFuturesBySportPage({ params }: PageProps<'/[locale]/sports/futures/[sportSlug]'>) {
   const { sportSlug } = await params
-  setRequestLocale(await getRootLocale())
   if (sportSlug === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(sportSlug)) {
       return null

--- a/src/app/[locale]/(platform)/sports/futures/page.tsx
+++ b/src/app/[locale]/(platform)/sports/futures/page.tsx
@@ -1,4 +1,3 @@
-import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -8,7 +7,6 @@ import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
 export default async function SportsFuturesRedirectPage({ params }: PageProps<'/[locale]/sports/futures'>) {
   const { locale } = await params
-  setRequestLocale(locale)
   const { data: futuresHref } = await SportsMenuRepository.getFuturesHref('sports')
   if (!futuresHref) {
     notFound()

--- a/src/app/[locale]/(platform)/sports/live/page.tsx
+++ b/src/app/[locale]/(platform)/sports/live/page.tsx
@@ -1,14 +1,11 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
-import { getRootLocale } from '@/i18n/root-locale'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateMetadata(): Promise<Metadata> {
-  setRequestLocale(await getRootLocale())
-
   const t = await getExtracted()
 
   const runtimeTheme = await loadRuntimeThemeState()
@@ -24,7 +21,6 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function SportsLivePage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return <SportsFeedPageContent sportSlug="live" sportTitle={t('Live')} pageMode="liveAndSoon" vertical="sports" />

--- a/src/app/[locale]/(platform)/sports/page.tsx
+++ b/src/app/[locale]/(platform)/sports/page.tsx
@@ -2,16 +2,14 @@
 
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import type { SupportedLocale } from '@/i18n/locales'
 
 import { redirect } from '@/i18n/navigation'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/sports'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   return { title: t('Sports') }
@@ -19,7 +17,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/sports'>
 
 export default async function SportsPage({ params }: PageProps<'/[locale]/sports'>) {
   const { locale } = await params
-  setRequestLocale(locale)
   const { data: landingHref } = await SportsMenuRepository.getLandingHref('sports')
 
   redirect({

--- a/src/app/[locale]/(platform)/sports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/sports/soon/page.tsx
@@ -1,19 +1,16 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
-import { getRootLocale } from '@/i18n/root-locale'
 
 export async function generateMetadata(): Promise<Metadata> {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return { title: t('Sports Upcoming') }
 }
 
 export default async function SportsSoonPage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/(platform)/tos/page.tsx
+++ b/src/app/[locale]/(platform)/tos/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from 'next'
 
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import TermsOfServiceDocument from '@/components/TermsOfServiceDocument'
 import { resolveSupportedLocale } from '@/i18n/locales'
@@ -9,10 +9,7 @@ import { TermsOfServiceRepository } from '@/lib/db/queries/terms-of-service'
 import resolveSiteUrl from '@/lib/site-url'
 import { getThemeSiteSettingsFormState, loadRuntimeThemeState } from '@/lib/theme-settings'
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/tos'>): Promise<Metadata> {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export async function generateMetadata(): Promise<Metadata> {
   const t = await getExtracted()
 
   const runtimeTheme = await loadRuntimeThemeState()
@@ -26,7 +23,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/tos'>): 
 
 export default async function TermsOfUsePage({ params }: PageProps<'/[locale]/tos'>) {
   const { locale } = await params
-  setRequestLocale(locale)
   const t = await getExtracted()
 
   const [{ data: allTermsOfServiceTranslations }, { data: allSettings }] = await Promise.all([

--- a/src/app/[locale]/2fa/layout.tsx
+++ b/src/app/[locale]/2fa/layout.tsx
@@ -1,8 +1,3 @@
-import { setRequestLocale } from 'next-intl/server'
-
-export default async function TwoFactorLayout({ params, children }: LayoutProps<'/[locale]/2fa'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function TwoFactorLayout({ children }: LayoutProps<'/[locale]/2fa'>) {
   return <main className="flex min-h-screen items-center justify-center px-4 py-12">{children}</main>
 }

--- a/src/app/[locale]/2fa/page.tsx
+++ b/src/app/[locale]/2fa/page.tsx
@@ -1,11 +1,6 @@
-import { setRequestLocale } from 'next-intl/server'
-
 import TwoFactorClient from '@/app/[locale]/2fa/_components/TwoFactorClient'
 
-export default async function TwoFactorPage({ params, searchParams }: PageProps<'/[locale]/2fa'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function TwoFactorPage({ searchParams }: PageProps<'/[locale]/2fa'>) {
   const resolvedSearchParams = searchParams ? await searchParams : undefined
   const nextValue = resolvedSearchParams?.next
   const next = Array.isArray(nextValue) ? nextValue[0] : nextValue

--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -642,7 +642,18 @@ async function syncGeoblockSettings() {
   throw new Error(detail || `Geoblock sync failed with status ${response.status}.`)
 }
 
-async function resolveCurrentLocale(): Promise<SupportedLocale> {
+function getLocaleOverride(formData: FormData): SupportedLocale | undefined {
+  const rawLocale = formData.get('locale')
+  return typeof rawLocale === 'string' && SUPPORTED_LOCALES.includes(rawLocale as SupportedLocale)
+    ? (rawLocale as SupportedLocale)
+    : undefined
+}
+
+async function resolveCurrentLocale(localeOverride?: SupportedLocale): Promise<SupportedLocale> {
+  if (localeOverride) {
+    return localeOverride
+  }
+
   try {
     const locale = await getLocale()
     return SUPPORTED_LOCALES.includes(locale as SupportedLocale) ? (locale as SupportedLocale) : DEFAULT_LOCALE
@@ -1154,7 +1165,7 @@ async function updateGeneralSettingsActionImpl(
 
   if (validatedHomeFeaturedData?.useAi) {
     await runOptionalGeneralSettingsTask('regenerate featured markets', async () => {
-      const locale = await resolveCurrentLocale()
+      const locale = await resolveCurrentLocale(getLocaleOverride(formData))
       const { regenerateHomeFeaturedEvents } = await import('@/lib/home-featured-ai')
       const regenerateResult = await regenerateHomeFeaturedEvents(locale, {
         settings: validatedHomeFeaturedData,

--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -644,8 +644,13 @@ async function syncGeoblockSettings() {
 
 function getLocaleOverride(formData: FormData): SupportedLocale | undefined {
   const rawLocale = formData.get('locale')
-  return typeof rawLocale === 'string' && SUPPORTED_LOCALES.includes(rawLocale as SupportedLocale)
-    ? (rawLocale as SupportedLocale)
+  if (typeof rawLocale !== 'string') {
+    return undefined
+  }
+
+  const normalizedLocale = rawLocale.trim().toLowerCase()
+  return SUPPORTED_LOCALES.includes(normalizedLocale as SupportedLocale)
+    ? (normalizedLocale as SupportedLocale)
     : undefined
 }
 

--- a/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
@@ -401,6 +401,7 @@ function AdminGeneralSettingsFormInner({
 
   return (
     <form action={formAction} className="grid max-w-full min-w-0 gap-6">
+      <input type="hidden" name="locale" value={locale} />
       <input type="hidden" name="logo_mode" value={logoMode} />
       <input type="hidden" name="logo_image_path" value={logoImagePath} />
       <input type="hidden" name="logo_svg" value={logoSvg} />

--- a/src/app/[locale]/admin/(general)/page.tsx
+++ b/src/app/[locale]/admin/(general)/page.tsx
@@ -9,7 +9,7 @@ import {
   UsersIcon,
   VolleyballIcon,
 } from 'lucide-react'
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { io } from 'next/cache'
 import { Suspense } from 'react'
 
@@ -260,9 +260,7 @@ async function AdminDashboardCards() {
   )
 }
 
-export default async function AdminDashboardPage({ params }: PageProps<'/[locale]/admin'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function AdminDashboardPage() {
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/affiliate/page.tsx
+++ b/src/app/[locale]/admin/affiliate/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { io } from 'next/cache'
 import { Suspense } from 'react'
 
@@ -204,9 +204,7 @@ async function AdminAffiliateContent() {
   )
 }
 
-export default async function AdminSettingsPage({ params }: PageProps<'/[locale]/admin/affiliate'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function AdminSettingsPage() {
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/categories/page.tsx
+++ b/src/app/[locale]/admin/categories/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { Suspense } from 'react'
 
 import AdminCategoriesTable from '@/app/[locale]/admin/categories/_components/AdminCategoriesTable'
@@ -27,9 +27,7 @@ function AdminCategoriesTableFallback() {
   )
 }
 
-export default async function AdminCategoriesPage({ params }: PageProps<'/[locale]/admin/categories'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function AdminCategoriesPage() {
   const t = await getExtracted()
   const enabledLocales = await loadEnabledLocales()
 

--- a/src/app/[locale]/admin/events/calendar/new/page.tsx
+++ b/src/app/[locale]/admin/events/calendar/new/page.tsx
@@ -1,5 +1,5 @@
 import { ArrowLeftIcon } from 'lucide-react'
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { Suspense } from 'react'
 
 import { AdminPanelSkeleton } from '@/app/[locale]/admin/_components/AdminPageSkeleton'
@@ -125,9 +125,7 @@ async function AdminCreateEventNewContent({ searchParams }: Pick<AdminCreateEven
   )
 }
 
-export default async function AdminCreateEventNewPage({ params, searchParams }: AdminCreateEventNewPageProps) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function AdminCreateEventNewPage({ searchParams }: AdminCreateEventNewPageProps) {
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/events/calendar/page.tsx
+++ b/src/app/[locale]/admin/events/calendar/page.tsx
@@ -1,12 +1,7 @@
-import { setRequestLocale } from 'next-intl/server'
-
 import AdminCreateEventCalendar from '@/app/[locale]/admin/events/calendar/_components/AdminCreateEventCalendar'
 
 export const instant = false
 
-export default async function AdminCreateEventPage({ params }: PageProps<'/[locale]/admin/events/calendar'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function AdminCreateEventPage() {
   return <AdminCreateEventCalendar />
 }

--- a/src/app/[locale]/admin/events/page.tsx
+++ b/src/app/[locale]/admin/events/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { Suspense } from 'react'
 
 import { DataTableSkeleton } from '@/app/[locale]/admin/_components/DataTableSkeleton'
@@ -35,7 +35,6 @@ async function AdminEventsContent() {
 }
 
 export default async function AdminEventsPage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/general/page.tsx
+++ b/src/app/[locale]/admin/general/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { io } from 'next/cache'
 import { Suspense } from 'react'
 
@@ -91,7 +91,6 @@ async function AdminGeneralSettingsContent() {
 }
 
 export default async function AdminGeneralSettingsPage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/integrations/page.tsx
+++ b/src/app/[locale]/admin/integrations/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { io } from 'next/cache'
 import { Suspense } from 'react'
 
@@ -97,7 +97,6 @@ async function AdminIntegrationsContent() {
 }
 
 export default async function AdminIntegrationsPage() {
-  setRequestLocale(await getRootLocale())
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/layout.tsx
+++ b/src/app/[locale]/admin/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata } from 'next'
 
-import { setRequestLocale } from 'next-intl/server'
 import { cacheTag } from 'next/cache'
 
 import PlatformViewerState from '@/app/[locale]/(platform)/_components/PlatformViewerState'
@@ -35,12 +34,10 @@ function getForkRepositoryUrl() {
   return `https://github.com/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoSlug)}`
 }
 
-export default async function AdminLayout({ params, children }: LayoutProps<'/[locale]/admin'>) {
+export default async function AdminLayout({ children }: LayoutProps<'/[locale]/admin'>) {
   'use cache'
 
   cacheTag(cacheTags.settings)
-  const { locale } = await params
-  setRequestLocale(locale)
   const forkRepositoryUrl = getForkRepositoryUrl()
   const { data: settings } = await SettingsRepository.getSettings()
   const supportSettings = getKuestSupportSettings(settings)

--- a/src/app/[locale]/admin/locales/_actions/update-locales-settings.ts
+++ b/src/app/[locale]/admin/locales/_actions/update-locales-settings.ts
@@ -10,7 +10,7 @@ import {
   serializeEnabledLocales,
   serializeLocaleOrder,
 } from '@/i18n/locale-settings'
-import { SUPPORTED_LOCALES } from '@/i18n/locales'
+import { resolveSupportedLocale, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { loadOpenRouterProviderSettings } from '@/lib/ai/market-context-config'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { SettingsRepository } from '@/lib/db/queries/settings'
@@ -60,7 +60,9 @@ export async function updateLocalesSettingsAction(
   _prevState: LocalesSettingsActionState,
   formData: FormData,
 ): Promise<LocalesSettingsActionState> {
-  const t = await getExtracted()
+  const rawLocale = formData.get('locale')
+  const locale = resolveSupportedLocale(typeof rawLocale === 'string' ? rawLocale : undefined)
+  const t = await getExtracted({ locale })
   const user = await UserRepository.getCurrentUser({ minimal: true })
 
   if (!user || !user.is_admin) {

--- a/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
+++ b/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
@@ -25,6 +25,7 @@ const initialState = {
 }
 
 interface AdminLocalesSettingsFormProps {
+  locale: string
   supportedLocales: readonly SupportedLocale[]
   enabledLocales: SupportedLocale[]
   localeOrder?: SupportedLocale[]
@@ -134,6 +135,7 @@ function useLocalesSettingsForm(
 }
 
 function AdminLocalesSettingsFormInner({
+  locale,
   supportedLocales,
   enabledLocales,
   localeOrder,
@@ -228,6 +230,7 @@ function AdminLocalesSettingsFormInner({
   return (
     <Form action={formAction} className="grid gap-4">
       <section className="grid gap-4 rounded-lg border p-6">
+        <input type="hidden" name="locale" value={locale} />
         <ul className="grid gap-2">
           {orderedLocales.map((locale, index) => {
             const isDefault = locale === DEFAULT_LOCALE
@@ -378,6 +381,7 @@ function useLocalesFormResetKey(props: AdminLocalesSettingsFormProps) {
   return useMemo(
     () =>
       JSON.stringify({
+        locale: props.locale,
         supportedLocales: props.supportedLocales,
         enabledLocales: props.enabledLocales,
         localeOrder: props.localeOrder,
@@ -386,6 +390,7 @@ function useLocalesFormResetKey(props: AdminLocalesSettingsFormProps) {
         isOpenRouterConfigured: props.isOpenRouterConfigured,
       }),
     [
+      props.locale,
       props.supportedLocales,
       props.enabledLocales,
       props.localeOrder,

--- a/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
+++ b/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
@@ -381,7 +381,6 @@ function useLocalesFormResetKey(props: AdminLocalesSettingsFormProps) {
   return useMemo(
     () =>
       JSON.stringify({
-        locale: props.locale,
         supportedLocales: props.supportedLocales,
         enabledLocales: props.enabledLocales,
         localeOrder: props.localeOrder,
@@ -390,7 +389,6 @@ function useLocalesFormResetKey(props: AdminLocalesSettingsFormProps) {
         isOpenRouterConfigured: props.isOpenRouterConfigured,
       }),
     [
-      props.locale,
       props.supportedLocales,
       props.enabledLocales,
       props.localeOrder,

--- a/src/app/[locale]/admin/locales/page.tsx
+++ b/src/app/[locale]/admin/locales/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { connection } from 'next/server'
 import { Suspense } from 'react'
 
@@ -25,7 +25,6 @@ async function AdminLocalesSettingsContent({ params }: PageProps<'/[locale]/admi
   'use cache'
 
   const { locale } = await params
-  setRequestLocale(locale)
   const t = await getExtracted()
 
   const { data: allSettings } = await SettingsRepository.getSettings()
@@ -46,6 +45,7 @@ async function AdminLocalesSettingsContent({ params }: PageProps<'/[locale]/admi
       </div>
 
       <AdminLocalesSettingsForm
+        locale={locale}
         supportedLocales={SUPPORTED_LOCALES}
         enabledLocales={enabledLocales}
         localeOrder={localeOrder ?? undefined}

--- a/src/app/[locale]/admin/market-making/page.tsx
+++ b/src/app/[locale]/admin/market-making/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import MarketMakingDiscovery from '@/app/[locale]/admin/market-making/_components/MarketMakingDiscovery'
 import { getRootLocale } from '@/i18n/root-locale'
@@ -18,7 +18,6 @@ export default async function AdminMarketMakingPage({ searchParams }: AdminMarke
   const locale = await getRootLocale()
   const resolvedSearchParams = await searchParams
   const linkedCampaignId = resolveCampaignId(resolvedSearchParams.campaign)
-  setRequestLocale(locale)
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/theme/page.tsx
+++ b/src/app/[locale]/admin/theme/page.tsx
@@ -1,4 +1,4 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { io } from 'next/cache'
 import { Suspense } from 'react'
 
@@ -49,9 +49,7 @@ async function AdminThemeSettingsContent() {
   )
 }
 
-export default async function AdminThemeSettingsPage({ params }: PageProps<'/[locale]/admin/theme'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function AdminThemeSettingsPage() {
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/admin/users/page.tsx
+++ b/src/app/[locale]/admin/users/page.tsx
@@ -1,12 +1,10 @@
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 
 import AdminUsersTable from '@/app/[locale]/admin/users/_components/AdminUsersTable'
 
 export const instant = false
 
-export default async function AdminUsersPage({ params }: PageProps<'/[locale]/admin/users'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function AdminUsersPage() {
   const t = await getExtracted()
 
   return (

--- a/src/app/[locale]/docs/[[...slug]]/layout.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/layout.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react'
 
 import { DocsLayout } from 'fumadocs-ui/layouts/docs'
 import { BookOpenIcon, HomeIcon, SquareTerminalIcon } from 'lucide-react'
-import { setRequestLocale } from 'next-intl/server'
 
 import DiscordIcon from '@/components/icons/DiscordIcon'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
@@ -27,9 +26,7 @@ export async function generateMetadata(): Promise<Metadata> {
   }
 }
 
-export default async function Layout({ params, children }: DocsSlugLayoutProps) {
-  const { locale } = await params
-  setRequestLocale(locale)
+export default async function Layout({ children }: DocsSlugLayoutProps) {
   const runtimeTheme = await loadRuntimeThemeState()
   const site = runtimeTheme.site
 

--- a/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -71,7 +71,8 @@ async function generateCachedDocsMetadata({ slug }: { slug?: string[] }): Promis
 }
 
 export async function generateMetadata(props: PageProps<'/[locale]/docs/[[...slug]]'>): Promise<Metadata> {
-  return generateCachedDocsMetadata(await props.params)
+  const { slug } = await props.params
+  return generateCachedDocsMetadata({ slug })
 }
 
 async function renderCachedDocsPage({ locale, slug }: { locale: string; slug?: string[] }) {

--- a/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from 'next'
 
 import { DocsBody, DocsDescription, DocsPage, DocsTitle } from 'fumadocs-ui/layouts/docs/page'
 import defaultMdxComponents from 'fumadocs-ui/mdx'
-import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { getExtracted } from 'next-intl/server'
 import { notFound, redirect } from 'next/navigation'
 
 import type { SupportedLocale } from '@/i18n/locales'
@@ -50,10 +50,9 @@ export async function generateStaticParams() {
   return getEnglishDocsStaticParams()
 }
 
-async function generateCachedDocsMetadata({ locale, slug }: { locale: string; slug?: string[] }): Promise<Metadata> {
+async function generateCachedDocsMetadata({ slug }: { slug?: string[] }): Promise<Metadata> {
   'use cache'
 
-  setRequestLocale(locale)
   const runtimeTheme = await loadRuntimeThemeState()
   const siteDocumentationTitle = `${runtimeTheme.site.name} Documentation`
 
@@ -78,7 +77,6 @@ export async function generateMetadata(props: PageProps<'/[locale]/docs/[[...slu
 async function renderCachedDocsPage({ locale, slug }: { locale: string; slug?: string[] }) {
   'use cache'
 
-  setRequestLocale(locale)
   const t = await getExtracted()
 
   const page = source.getPage(slug)

--- a/src/app/[locale]/docs/layout.tsx
+++ b/src/app/[locale]/docs/layout.tsx
@@ -1,12 +1,7 @@
-import { setRequestLocale } from 'next-intl/server'
-
 import { DocsRootProvider } from '@/app/[locale]/docs/_components/DocsRootProvider'
 
 import './docs.css'
 
-export default async function Layout({ params, children }: LayoutProps<'/[locale]/docs'>) {
-  const { locale } = await params
-  setRequestLocale(locale)
-
+export default async function Layout({ children }: LayoutProps<'/[locale]/docs'>) {
   return <DocsRootProvider>{children}</DocsRootProvider>
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -2,7 +2,6 @@ import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
 
 import { NextIntlClientProvider } from 'next-intl'
-import { setRequestLocale } from 'next-intl/server'
 import { cacheTag } from 'next/cache'
 import { notFound } from 'next/navigation'
 
@@ -137,8 +136,6 @@ async function loadLocaleRuntimeData(locale: SupportedLocale): Promise<LocaleRun
   const globalAnnouncement = await loadGlobalAnnouncementSettings()
   const hasGlobalAnnouncement = globalAnnouncement.message.trim().length > 0
 
-  setRequestLocale(locale)
-
   return {
     globalAnnouncement,
     hasGlobalAnnouncement,
@@ -243,9 +240,6 @@ async function RuntimeLocaleDocument({ children }: LocaleDocumentProps) {
 }
 
 export default async function LocaleLayout({ children }: LayoutProps<'/[locale]'>) {
-  const locale = await getRootLocale()
-  setRequestLocale(locale)
-
   return shouldPrerenderPublicShell() ? (
     <PrerenderedLocaleDocument>{children}</PrerenderedLocaleDocument>
   ) : (

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,15 +1,19 @@
 import { hasLocale } from 'next-intl'
 import { getRequestConfig } from 'next-intl/server'
+import { notFound } from 'next/navigation'
+import { locale as rootLocale } from 'next/root-params'
 
 import { routing } from './routing'
 
-export default getRequestConfig(async ({ requestLocale }) => {
-  const requested = await requestLocale
-  const locale = hasLocale(routing.locales, requested) ? requested : routing.defaultLocale
+export default getRequestConfig(async ({ locale: localeOverride }) => {
+  const requested = localeOverride ?? (await rootLocale())
+  if (!hasLocale(routing.locales, requested)) {
+    notFound()
+  }
 
   return {
-    locale,
+    locale: requested,
     timeZone: 'America/New_York',
-    messages: (await import(`./messages/${locale}.json`)).default,
+    messages: (await import(`./messages/${requested}.json`)).default,
   }
 })

--- a/src/lib/orders/index.ts
+++ b/src/lib/orders/index.ts
@@ -25,6 +25,7 @@ export interface BuildOrderPayloadArgs extends CalculateOrderAmountsArgs {
 }
 
 export interface SubmitOrderArgs {
+  locale?: string
   order: BlockchainOrder
   signature: string
   orderType: OrderType
@@ -174,6 +175,7 @@ function toStoreOrderInput({
   postOnly,
   conditionId,
   slug,
+  locale,
 }: SubmitOrderArgs) {
   return {
     ...serializeOrder(order),
@@ -184,6 +186,7 @@ function toStoreOrderInput({
     ...(typeof postOnly === 'boolean' ? { post_only: postOnly } : {}),
     condition_id: conditionId,
     slug,
+    ...(locale ? { locale } : {}),
   }
 }
 
@@ -195,6 +198,7 @@ export async function submitOrder({
   postOnly,
   conditionId,
   slug,
+  locale,
 }: SubmitOrderArgs) {
   return storeOrderAction(
     toStoreOrderInput({
@@ -205,6 +209,7 @@ export async function submitOrder({
       postOnly,
       conditionId,
       slug,
+      locale,
     }),
   )
 }

--- a/tests/unit/AdminLocalesSettingsForm.test.tsx
+++ b/tests/unit/AdminLocalesSettingsForm.test.tsx
@@ -81,4 +81,18 @@ describe('adminLocalesSettingsForm', () => {
       ),
     ).toEqual(['en', 'fr', 'de'])
   })
+
+  it('preserves unsaved changes when the UI locale changes', () => {
+    const view = render(<AdminLocalesSettingsForm {...props} />)
+
+    fireEvent.click(view.getByRole('button', { name: 'Move Deutsch up' }))
+    view.rerender(<AdminLocalesSettingsForm {...props} locale="pt" />)
+
+    expect(
+      Array.from(view.container.querySelectorAll('input[name="enabled_locales"]')).map((input) =>
+        input.getAttribute('value'),
+      ),
+    ).toEqual(['en', 'de', 'fr'])
+    expect(view.container.querySelector('input[name="locale"]')).toHaveValue('pt')
+  })
 })

--- a/tests/unit/AdminLocalesSettingsForm.test.tsx
+++ b/tests/unit/AdminLocalesSettingsForm.test.tsx
@@ -40,6 +40,7 @@ void mock.module('@/i18n/navigation', () => ({
 }))
 
 const props = {
+  locale: 'en',
   supportedLocales: ['en', 'de', 'es', 'pt', 'fr'] as const,
   enabledLocales: ['en', 'fr', 'de'] as SupportedLocale[],
   localeOrder: ['en', 'fr', 'de', 'pt', 'es'] as SupportedLocale[],

--- a/tests/unit/PopularPredictionsPage.test.tsx
+++ b/tests/unit/PopularPredictionsPage.test.tsx
@@ -5,13 +5,11 @@ import { hoisted } from '../bun-test-helpers'
 const mocks = hoisted(() => ({
   generatePredictionResultsMetadata: mock(),
   renderPredictionResultsPage: mock(),
-  setRequestLocale: mock(),
   translate: mock((value: string) => value),
 }))
 
 void mock.module('next-intl/server', () => ({
   getExtracted: mock(async () => mocks.translate),
-  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
 }))
 
 void mock.module('@/app/[locale]/(platform)/predictions/[slug]/_lib/prediction-results-page', () => ({
@@ -23,7 +21,6 @@ describe('popular predictions page', () => {
   beforeEach(() => {
     mocks.generatePredictionResultsMetadata.mockReset()
     mocks.renderPredictionResultsPage.mockReset()
-    mocks.setRequestLocale.mockReset()
     mocks.translate.mockClear()
     mocks.renderPredictionResultsPage.mockResolvedValue(null)
   })

--- a/tests/unit/PredictionResultsPage.test.tsx
+++ b/tests/unit/PredictionResultsPage.test.tsx
@@ -5,11 +5,6 @@ import { hoisted } from '../bun-test-helpers'
 const mocks = hoisted(() => ({
   notFound: mock(),
   renderPredictionResultsPage: mock(),
-  setRequestLocale: mock(),
-}))
-
-void mock.module('next-intl/server', () => ({
-  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
 }))
 
 void mock.module('next/navigation', () => ({
@@ -31,7 +26,6 @@ describe('prediction results page', () => {
   beforeEach(() => {
     mocks.notFound.mockReset()
     mocks.renderPredictionResultsPage.mockReset()
-    mocks.setRequestLocale.mockReset()
     mocks.renderPredictionResultsPage.mockResolvedValue(null)
   })
 

--- a/tests/unit/TermsOfUsePage.test.tsx
+++ b/tests/unit/TermsOfUsePage.test.tsx
@@ -8,12 +8,10 @@ const mocks = hoisted(() => ({
   getTranslations: mock(),
   getThemeSiteSettingsFormState: mock(),
   loadRuntimeThemeState: mock(),
-  setRequestLocale: mock(),
 }))
 
 void mock.module('next-intl/server', () => ({
   getExtracted: () => (value: string) => value,
-  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
 }))
 
 void mock.module('@/lib/db/queries/settings', () => ({
@@ -39,7 +37,6 @@ describe('termsOfUsePage', () => {
     mocks.getTranslations.mockReset()
     mocks.getThemeSiteSettingsFormState.mockReset()
     mocks.loadRuntimeThemeState.mockReset()
-    mocks.setRequestLocale.mockReset()
 
     mocks.getSettings.mockResolvedValue({ data: {}, error: null })
     mocks.getTranslations.mockResolvedValue({

--- a/tests/unit/TradingOnboardingDialogs.test.tsx
+++ b/tests/unit/TradingOnboardingDialogs.test.tsx
@@ -302,6 +302,41 @@ describe('tradingOnboardingDialogs', () => {
     expect(onEmailSkip).toHaveBeenCalledTimes(1)
   })
 
+  it('resets the email draft when the dialog is reopened', async () => {
+    const user = userEvent.setup()
+    const view = render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'email',
+          emailDefaultValue: 'first@example.com',
+        })}
+      />,
+    )
+
+    const input = screen.getByPlaceholderText('Email address')
+    await user.clear(input)
+    await user.type(input, 'draft@example.com')
+
+    view.rerender(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: null,
+          emailDefaultValue: 'updated@example.com',
+        })}
+      />,
+    )
+    view.rerender(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'email',
+          emailDefaultValue: 'updated@example.com',
+        })}
+      />,
+    )
+
+    expect(screen.getByPlaceholderText('Email address')).toHaveValue('updated@example.com')
+  })
+
   it('keeps enable trading non-dismissible until an error appears', async () => {
     const user = userEvent.setup()
     const onModalOpenChange = mock()

--- a/tests/unit/adminSettingsPagesCache.test.tsx
+++ b/tests/unit/adminSettingsPagesCache.test.tsx
@@ -8,7 +8,6 @@ import { hoisted } from '../bun-test-helpers'
 const mocks = hoisted(() => ({
   io: mock(),
   getExtracted: mock(),
-  setRequestLocale: mock(),
   getSettings: mock(),
   redirect: mock(),
 }))
@@ -20,7 +19,6 @@ void mock.module('next/cache', () => ({
 
 void mock.module('next-intl/server', () => ({
   getExtracted: (...args: any[]) => mocks.getExtracted(...args),
-  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
 }))
 
 void mock.module('next/navigation', () => ({
@@ -58,7 +56,6 @@ describe('admin settings pages runtime behavior', () => {
   beforeEach(() => {
     mocks.io.mockReset()
     mocks.getExtracted.mockReset()
-    mocks.setRequestLocale.mockReset()
     mocks.getSettings.mockReset()
     mocks.redirect.mockReset()
 

--- a/tests/unit/adminUsersCommunityFollowsProvider.test.tsx
+++ b/tests/unit/adminUsersCommunityFollowsProvider.test.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react'
 import { render, screen } from '@testing-library/react'
 import { describe, expect, it, mock } from 'bun:test'
 
-void mock.module('next-intl/server', () => ({ setRequestLocale: mock() }))
 void mock.module('next/cache', () => ({ cacheTag: mock() }))
 
 void mock.module('@/app/[locale]/(platform)/_components/PlatformViewerState', () => ({ default: () => null }))

--- a/tests/unit/leaderboardMetadata.test.ts
+++ b/tests/unit/leaderboardMetadata.test.ts
@@ -8,12 +8,10 @@ const mocks = hoisted(() => ({
   getExtracted: mock(),
   loadRuntimeThemeState: mock(),
   resolveSiteUrl: mock(),
-  setRequestLocale: mock(),
 }))
 
 void mock.module('next-intl/server', () => ({
   getExtracted: (...args: any[]) => mocks.getExtracted(...args),
-  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
 }))
 
 void mock.module('@/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient', () => ({
@@ -43,7 +41,6 @@ describe('leaderboard metadata', () => {
     mocks.getExtracted.mockReset()
     mocks.loadRuntimeThemeState.mockReset()
     mocks.resolveSiteUrl.mockReset()
-    mocks.setRequestLocale.mockReset()
 
     mocks.deferPublicShellPrerenderIfNeeded.mockImplementation(async () => {
       mocks.calls.push('defer')

--- a/tests/unit/localeLayout.test.tsx
+++ b/tests/unit/localeLayout.test.tsx
@@ -11,16 +11,11 @@ const mocks = hoisted(() => ({
   loadEnabledLocales: mock(),
   loadGlobalAnnouncementSettings: mock(),
   loadRuntimeThemeState: mock(),
-  setRequestLocale: mock(),
 }))
 
 void mock.module('next-intl', () => ({
   hasLocale: () => true,
   NextIntlClientProvider: 'next-intl-provider',
-}))
-
-void mock.module('next-intl/server', () => ({
-  setRequestLocale: (...args: unknown[]) => mocks.setRequestLocale(...args),
 }))
 
 void mock.module('next/cache', () => ({

--- a/tests/unit/storeOrderAction.test.ts
+++ b/tests/unit/storeOrderAction.test.ts
@@ -556,6 +556,32 @@ describe('storeOrderAction', () => {
     expect(mocks.createOrder).not.toHaveBeenCalled()
   })
 
+  it.each([null, undefined])('returns a validation error for malformed batch input: %s', async (payloads) => {
+    process.env.CLOB_URL = 'https://clob.local'
+    const depositWallet = address('01')
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      address: address('aa'),
+      deposit_wallet_address: depositWallet,
+      referred_by_user_id: null,
+      settings: { trading: { market_order_type: 'FAK' } },
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: { key: 'k', passphrase: 'p', secret: 's' },
+    })
+    const fetchMock = mock()
+    globalThis.fetch = fetchMock as any
+
+    const { storeOrdersAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
+    const result = await storeOrdersAction(payloads as StoreOrdersInput)
+
+    expect(result).toEqual({
+      error: 'Something went wrong while processing your order. Please try again.',
+      results: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('preserves individual failures returned by the CLOB batch endpoint', async () => {
     process.env.CLOB_URL = 'https://clob.local'
     const depositWallet = address('01')
@@ -596,6 +622,55 @@ describe('storeOrderAction', () => {
       results: [
         { error: null, orderId: 'yes-123' },
         { error: 'Not enough liquidity to fully fill this order right now.', orderId: null },
+      ],
+    })
+  })
+
+  it('uses each order locale for individual batch errors', async () => {
+    process.env.CLOB_URL = 'https://clob.local'
+    const depositWallet = address('01')
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      address: address('aa'),
+      deposit_wallet_address: depositWallet,
+      referred_by_user_id: null,
+      settings: { trading: { market_order_type: 'FAK' } },
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: { key: 'k', passphrase: 'p', secret: 's' },
+    })
+    mocks.getExtracted.mockImplementation(
+      async ({ locale }: { locale: string }) =>
+        (message: string) =>
+          `${locale}:${message}`,
+    )
+
+    globalThis.fetch = mock().mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      ok: true,
+      json: async () => [
+        { success: true, errorMsg: '', orderID: 'yes-123', status: 'matched' },
+        {
+          success: false,
+          errorMsg: "order couldn't be fully filled, FOK orders are fully filled/killed",
+          orderID: '',
+          status: 'unmatched',
+        },
+      ],
+    }) as any
+
+    const { storeOrdersAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
+    const result = await storeOrdersAction([
+      basePayload({ maker: depositWallet, signer: depositWallet, token_id: '1' }),
+      basePayload({ maker: depositWallet, signer: depositWallet, token_id: '2', salt: '2', locale: 'pt' }),
+    ])
+
+    expect(result).toEqual({
+      error: null,
+      results: [
+        { error: null, orderId: 'yes-123' },
+        { error: 'pt:Not enough liquidity to fully fill this order right now.', orderId: null },
       ],
     })
   })

--- a/tests/unit/storeOrderAction.test.ts
+++ b/tests/unit/storeOrderAction.test.ts
@@ -582,6 +582,36 @@ describe('storeOrderAction', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('uses a supported raw locale when batch schema validation fails', async () => {
+    process.env.CLOB_URL = 'https://clob.local'
+    const depositWallet = address('01')
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      address: address('aa'),
+      deposit_wallet_address: depositWallet,
+      referred_by_user_id: null,
+      settings: { trading: { market_order_type: 'FAK' } },
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: { key: 'k', passphrase: 'p', secret: 's' },
+    })
+    mocks.getExtracted.mockImplementation(
+      async ({ locale }: { locale: string }) =>
+        (message: string) =>
+          `${locale}:${message}`,
+    )
+
+    const { storeOrdersAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
+    const result = await storeOrdersAction([
+      { ...basePayload({ locale: 'pt', maker: depositWallet, signer: depositWallet }), side: 2 },
+    ] as unknown as StoreOrdersInput)
+
+    expect(result).toEqual({
+      error: 'pt:Something went wrong while processing your order. Please try again.',
+      results: null,
+    })
+  })
+
   it('preserves individual failures returned by the CLOB batch endpoint', async () => {
     process.env.CLOB_URL = 'https://clob.local'
     const depositWallet = address('01')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches locale resolution to `next-intl` root params and removes `setRequestLocale` calls across the app. Unsupported locales now return 404 instead of falling back to the default locale, and order server actions translate CLOB errors in the request's locale.

**Refactors**
- `src/i18n/request.ts` reads `locale` from `next/root-params` or the request config override and calls `notFound()` for unsupported locales.
- Removes `setRequestLocale` from all pages and layouts, relying on root params instead.
- Passes `locale` from `useLocale()` through order submission to `storeOrderAction` and `storeOrdersAction`; batch order errors use each order's locale.
- Adds hidden `locale` inputs to the general and locales admin settings forms so their server actions resolve the correct locale.
- Removes `setRequestLocale` mocks from unit tests.
- Bumps Bun to 1.4.2 in the Dockerfile, CI workflow, and engine requirements.

**Bug Fixes**
- The `TradingOnboardingDialogs` email dialog now uses simple state for edit tracking instead of refs, eliminating stale default value syncing.

<sup>Written for commit 33599ca29f3e6e05c3f417a43a5a824f5ff90ea9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

