### PR TITLE
fix: preserve SSL mode for Bun database migrations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,13 @@ RESOLUTION_REPORT_MIN_TRADED_MARKETS=5
 BUILD_PRERENDER_PUBLIC_SHELL=""
 
 # PostgreSQL runtime connection (required outside Vercel/Supabase integration flow)
+# For hosted Supabase, include sslmode=require in the connection URL.
 POSTGRES_URL=""
+
+# Optional migration connection; falls back to POSTGRES_URL when empty.
+# Use a direct or session-pooler URL (migrations use session advisory locks).
+# For hosted Supabase, include sslmode=require in this URL too.
+POSTGRES_URL_NON_POOLING=""
 
 # Supabase credentials (optional outside Supabase mode; if one is set, both are required)
 SUPABASE_URL=""

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -461,7 +461,8 @@ function resolveMigrationConnectionString(): string | null {
     return null
   }
 
-  return migrationUrl.replace('require', 'disable')
+  // Preserve SSL options: Supabase can require TLS for migration connections too.
+  return migrationUrl
 }
 
 async function acquireMigrationLock(sql: ReservedSql): Promise<void> {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes migration SSL handling so Bun database migrations preserve the SSL mode from the connection URL instead of forcing it to disable, which could break migrations on hosted Supabase. Also adds optional `POSTGRES_URL_NON_POOLING` for migrations, falling back to `POSTGRES_URL` when empty.

<sup>Written for commit 21d5ddf17e95cfd0212bcf1b2a7e4a8cf3383d13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

