### PR TITLE
fix: remove noisy first-run migration notices

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,7 +24,7 @@ BETTER_AUTH_SECRET=""
 # Vercel Cron Jobs (Create a random secret of at least 16 characters)
 CRON_SECRET=""
 
-# Database connection
+# Database connection (required outside the Vercel/Supabase integration flow; auto-provisioned by the integration)
 POSTGRES_URL=""
 
 # ============================================================

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,9 @@ BETTER_AUTH_SECRET=""
 # Vercel Cron Jobs (Create a random secret of at least 16 characters)
 CRON_SECRET=""
 
+# Database connection
+POSTGRES_URL=""
+
 # ============================================================
 # OPTIONAL
 # ============================================================
@@ -45,13 +48,8 @@ RESOLUTION_REPORT_MIN_TRADED_MARKETS=5
 # Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.
 BUILD_PRERENDER_PUBLIC_SHELL=""
 
-# PostgreSQL runtime connection (required outside Vercel/Supabase integration flow)
-# For hosted Supabase, include sslmode=require in the connection URL.
-POSTGRES_URL=""
-
 # Optional migration connection; falls back to POSTGRES_URL when empty.
 # Use a direct or session-pooler URL (migrations use session advisory locks).
-# For hosted Supabase, include sslmode=require in this URL too.
 POSTGRES_URL_NON_POOLING=""
 
 # Supabase credentials (optional outside Supabase mode; if one is set, both are required)

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -461,7 +461,6 @@ function resolveMigrationConnectionString(): string | null {
     return null
   }
 
-  // Preserve SSL options: Supabase can require TLS for migration connections too.
   return migrationUrl
 }
 

--- a/src/lib/db/migrations/2026_02_22_001_event_start_date.sql
+++ b/src/lib/db/migrations/2026_02_22_001_event_start_date.sql
@@ -29,6 +29,19 @@ CREATE INDEX IF NOT EXISTS idx_series_social_trackers_series_slug_active
 ALTER TABLE series_social_trackers
   ENABLE ROW LEVEL SECURITY;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'series_social_trackers'
+      AND policyname = 'service_role_all_series_social_trackers'
+  ) THEN
+    DROP POLICY "service_role_all_series_social_trackers" ON "series_social_trackers";
+  END IF;
+END $$;
+
 CREATE POLICY "service_role_all_series_social_trackers"
   ON "series_social_trackers"
   AS PERMISSIVE
@@ -36,6 +49,19 @@ CREATE POLICY "service_role_all_series_social_trackers"
   TO "service_role"
   USING (TRUE)
   WITH CHECK (TRUE);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'series_social_trackers'::regclass
+      AND tgname = 'set_series_social_trackers_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_series_social_trackers_updated_at ON series_social_trackers;
+  END IF;
+END $$;
 
 CREATE TRIGGER set_series_social_trackers_updated_at
   BEFORE UPDATE

--- a/src/lib/db/migrations/2026_02_22_001_event_start_date.sql
+++ b/src/lib/db/migrations/2026_02_22_001_event_start_date.sql
@@ -29,7 +29,6 @@ CREATE INDEX IF NOT EXISTS idx_series_social_trackers_series_slug_active
 ALTER TABLE series_social_trackers
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_series_social_trackers" ON "series_social_trackers";
 CREATE POLICY "service_role_all_series_social_trackers"
   ON "series_social_trackers"
   AS PERMISSIVE
@@ -38,7 +37,6 @@ CREATE POLICY "service_role_all_series_social_trackers"
   USING (TRUE)
   WITH CHECK (TRUE);
 
-DROP TRIGGER IF EXISTS set_series_social_trackers_updated_at ON series_social_trackers;
 CREATE TRIGGER set_series_social_trackers_updated_at
   BEFORE UPDATE
   ON series_social_trackers

--- a/src/lib/db/migrations/2026_02_23_001_sports_metadata_fields.sql
+++ b/src/lib/db/migrations/2026_02_23_001_sports_metadata_fields.sql
@@ -114,7 +114,6 @@ ALTER TABLE event_sports
 ALTER TABLE market_sports
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_event_sports" ON "event_sports";
 CREATE POLICY "service_role_all_event_sports"
   ON "event_sports"
   AS PERMISSIVE
@@ -123,7 +122,6 @@ CREATE POLICY "service_role_all_event_sports"
   USING (TRUE)
   WITH CHECK (TRUE);
 
-DROP POLICY IF EXISTS "service_role_all_market_sports" ON "market_sports";
 CREATE POLICY "service_role_all_market_sports"
   ON "market_sports"
   AS PERMISSIVE

--- a/src/lib/db/migrations/2026_02_23_001_sports_metadata_fields.sql
+++ b/src/lib/db/migrations/2026_02_23_001_sports_metadata_fields.sql
@@ -114,6 +114,19 @@ ALTER TABLE event_sports
 ALTER TABLE market_sports
   ENABLE ROW LEVEL SECURITY;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'event_sports'
+      AND policyname = 'service_role_all_event_sports'
+  ) THEN
+    DROP POLICY "service_role_all_event_sports" ON "event_sports";
+  END IF;
+END $$;
+
 CREATE POLICY "service_role_all_event_sports"
   ON "event_sports"
   AS PERMISSIVE
@@ -121,6 +134,19 @@ CREATE POLICY "service_role_all_event_sports"
   TO "service_role"
   USING (TRUE)
   WITH CHECK (TRUE);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'market_sports'
+      AND policyname = 'service_role_all_market_sports'
+  ) THEN
+    DROP POLICY "service_role_all_market_sports" ON "market_sports";
+  END IF;
+END $$;
 
 CREATE POLICY "service_role_all_market_sports"
   ON "market_sports"

--- a/src/lib/db/migrations/2026_02_24_001_sports_menu_items.sql
+++ b/src/lib/db/migrations/2026_02_24_001_sports_menu_items.sql
@@ -224,6 +224,19 @@ ON CONFLICT (id) DO UPDATE SET
 ALTER TABLE sports_menu_items
   ENABLE ROW LEVEL SECURITY;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'sports_menu_items'
+      AND policyname = 'service_role_all_sports_menu_items'
+  ) THEN
+    DROP POLICY "service_role_all_sports_menu_items" ON "sports_menu_items";
+  END IF;
+END $$;
+
 CREATE POLICY "service_role_all_sports_menu_items"
   ON "sports_menu_items"
   AS PERMISSIVE

--- a/src/lib/db/migrations/2026_02_24_001_sports_menu_items.sql
+++ b/src/lib/db/migrations/2026_02_24_001_sports_menu_items.sql
@@ -224,7 +224,6 @@ ON CONFLICT (id) DO UPDATE SET
 ALTER TABLE sports_menu_items
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_sports_menu_items" ON "sports_menu_items";
 CREATE POLICY "service_role_all_sports_menu_items"
   ON "sports_menu_items"
   AS PERMISSIVE

--- a/src/lib/db/migrations/2026_03_15_001_allowed_market_creators.sql
+++ b/src/lib/db/migrations/2026_03_15_001_allowed_market_creators.sql
@@ -26,6 +26,19 @@ CREATE INDEX IF NOT EXISTS idx_allowed_market_creators_source_url
 ALTER TABLE allowed_market_creators
   ENABLE ROW LEVEL SECURITY;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'allowed_market_creators'
+      AND policyname = 'service_role_all_allowed_market_creators'
+  ) THEN
+    DROP POLICY "service_role_all_allowed_market_creators" ON "allowed_market_creators";
+  END IF;
+END $$;
+
 CREATE POLICY "service_role_all_allowed_market_creators"
   ON "allowed_market_creators"
   AS PERMISSIVE
@@ -33,6 +46,19 @@ CREATE POLICY "service_role_all_allowed_market_creators"
   TO "service_role"
   USING (TRUE)
   WITH CHECK (TRUE);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'allowed_market_creators'::regclass
+      AND tgname = 'set_allowed_market_creators_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_allowed_market_creators_updated_at ON allowed_market_creators;
+  END IF;
+END $$;
 
 CREATE TRIGGER set_allowed_market_creators_updated_at
   BEFORE UPDATE

--- a/src/lib/db/migrations/2026_03_15_001_allowed_market_creators.sql
+++ b/src/lib/db/migrations/2026_03_15_001_allowed_market_creators.sql
@@ -26,7 +26,6 @@ CREATE INDEX IF NOT EXISTS idx_allowed_market_creators_source_url
 ALTER TABLE allowed_market_creators
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_allowed_market_creators" ON "allowed_market_creators";
 CREATE POLICY "service_role_all_allowed_market_creators"
   ON "allowed_market_creators"
   AS PERMISSIVE
@@ -35,7 +34,6 @@ CREATE POLICY "service_role_all_allowed_market_creators"
   USING (TRUE)
   WITH CHECK (TRUE);
 
-DROP TRIGGER IF EXISTS set_allowed_market_creators_updated_at ON allowed_market_creators;
 CREATE TRIGGER set_allowed_market_creators_updated_at
   BEFORE UPDATE
   ON allowed_market_creators

--- a/src/lib/db/migrations/2026_03_22_001_event_creations.sql
+++ b/src/lib/db/migrations/2026_03_22_001_event_creations.sql
@@ -64,6 +64,19 @@ CREATE INDEX IF NOT EXISTS idx_event_creations_source_event_id
 ALTER TABLE event_creations
   ENABLE ROW LEVEL SECURITY;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'event_creations'
+      AND policyname = 'service_role_all_event_creations'
+  ) THEN
+    DROP POLICY "service_role_all_event_creations" ON "event_creations";
+  END IF;
+END $$;
+
 CREATE POLICY "service_role_all_event_creations"
   ON "event_creations"
   AS PERMISSIVE
@@ -71,6 +84,19 @@ CREATE POLICY "service_role_all_event_creations"
   TO "service_role"
   USING (TRUE)
   WITH CHECK (TRUE);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'event_creations'::regclass
+      AND tgname = 'set_event_creations_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_event_creations_updated_at ON event_creations;
+  END IF;
+END $$;
 
 CREATE TRIGGER set_event_creations_updated_at
   BEFORE UPDATE

--- a/src/lib/db/migrations/2026_03_22_001_event_creations.sql
+++ b/src/lib/db/migrations/2026_03_22_001_event_creations.sql
@@ -64,7 +64,6 @@ CREATE INDEX IF NOT EXISTS idx_event_creations_source_event_id
 ALTER TABLE event_creations
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_event_creations" ON "event_creations";
 CREATE POLICY "service_role_all_event_creations"
   ON "event_creations"
   AS PERMISSIVE
@@ -73,7 +72,6 @@ CREATE POLICY "service_role_all_event_creations"
   USING (TRUE)
   WITH CHECK (TRUE);
 
-DROP TRIGGER IF EXISTS set_event_creations_updated_at ON event_creations;
 CREATE TRIGGER set_event_creations_updated_at
   BEFORE UPDATE
   ON event_creations

--- a/src/lib/db/migrations/2026_04_06_002_market_context_cache.sql
+++ b/src/lib/db/migrations/2026_04_06_002_market_context_cache.sql
@@ -18,6 +18,19 @@ CREATE INDEX IF NOT EXISTS idx_market_context_cache_expires_at
 ALTER TABLE market_context_cache
   ENABLE ROW LEVEL SECURITY;
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'market_context_cache'
+      AND policyname = 'service_role_all_market_context_cache'
+  ) THEN
+    DROP POLICY "service_role_all_market_context_cache" ON "market_context_cache";
+  END IF;
+END $$;
+
 CREATE POLICY "service_role_all_market_context_cache"
   ON "market_context_cache"
   AS PERMISSIVE
@@ -25,6 +38,19 @@ CREATE POLICY "service_role_all_market_context_cache"
   TO "service_role"
   USING (TRUE)
   WITH CHECK (TRUE);
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'market_context_cache'::regclass
+      AND tgname = 'set_market_context_cache_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_market_context_cache_updated_at ON market_context_cache;
+  END IF;
+END $$;
 
 CREATE TRIGGER set_market_context_cache_updated_at
   BEFORE UPDATE

--- a/src/lib/db/migrations/2026_04_06_002_market_context_cache.sql
+++ b/src/lib/db/migrations/2026_04_06_002_market_context_cache.sql
@@ -18,7 +18,6 @@ CREATE INDEX IF NOT EXISTS idx_market_context_cache_expires_at
 ALTER TABLE market_context_cache
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_market_context_cache" ON "market_context_cache";
 CREATE POLICY "service_role_all_market_context_cache"
   ON "market_context_cache"
   AS PERMISSIVE
@@ -27,7 +26,6 @@ CREATE POLICY "service_role_all_market_context_cache"
   USING (TRUE)
   WITH CHECK (TRUE);
 
-DROP TRIGGER IF EXISTS set_market_context_cache_updated_at ON market_context_cache;
 CREATE TRIGGER set_market_context_cache_updated_at
   BEFORE UPDATE
   ON market_context_cache

--- a/src/lib/db/migrations/2026_05_06_001_deposit_wallet_cutover.sql
+++ b/src/lib/db/migrations/2026_05_06_001_deposit_wallet_cutover.sql
@@ -72,11 +72,28 @@ BEGIN
   END IF;
 END $$;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_deposit_wallet_address
-  ON users (LOWER(deposit_wallet_address));
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = current_schema()
+      AND indexname = 'idx_users_deposit_wallet_address'
+  ) THEN
+    CREATE UNIQUE INDEX idx_users_deposit_wallet_address
+      ON users (LOWER(deposit_wallet_address));
+  END IF;
 
-CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username
-  ON users (LOWER(username));
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_indexes
+    WHERE schemaname = current_schema()
+      AND indexname = 'idx_users_username'
+  ) THEN
+    CREATE UNIQUE INDEX idx_users_username
+      ON users (LOWER(username));
+  END IF;
+END $$;
 
 ALTER TABLE users
   ALTER COLUMN deposit_wallet_status DROP NOT NULL,

--- a/src/lib/db/migrations/2026_06_28_001_home_featured_events.sql
+++ b/src/lib/db/migrations/2026_06_28_001_home_featured_events.sql
@@ -45,6 +45,19 @@ ALTER TABLE home_featured_events
 
 DO $$
 BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'home_featured_events'
+      AND policyname = 'service_role_all_home_featured_events'
+  ) THEN
+    DROP POLICY "service_role_all_home_featured_events" ON "home_featured_events";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
     CREATE POLICY "service_role_all_home_featured_events"
       ON "home_featured_events"
@@ -53,6 +66,19 @@ BEGIN
       TO "service_role"
       USING (TRUE)
       WITH CHECK (TRUE);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'home_featured_events'::regclass
+      AND tgname = 'set_home_featured_events_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_home_featured_events_updated_at ON home_featured_events;
   END IF;
 END $$;
 
@@ -97,6 +123,19 @@ ALTER TABLE home_featured_event_context_items
 
 DO $$
 BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_policies
+    WHERE schemaname = current_schema()
+      AND tablename = 'home_featured_event_context_items'
+      AND policyname = 'service_role_all_home_featured_event_context_items'
+  ) THEN
+    DROP POLICY "service_role_all_home_featured_event_context_items" ON "home_featured_event_context_items";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
     CREATE POLICY "service_role_all_home_featured_event_context_items"
       ON "home_featured_event_context_items"
@@ -105,6 +144,19 @@ BEGIN
       TO "service_role"
       USING (TRUE)
       WITH CHECK (TRUE);
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'home_featured_event_context_items'::regclass
+      AND tgname = 'set_home_featured_event_context_items_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_home_featured_event_context_items_updated_at ON home_featured_event_context_items;
   END IF;
 END $$;
 

--- a/src/lib/db/migrations/2026_06_28_001_home_featured_events.sql
+++ b/src/lib/db/migrations/2026_06_28_001_home_featured_events.sql
@@ -43,7 +43,6 @@ CREATE INDEX IF NOT EXISTS idx_home_featured_events_ends_at
 ALTER TABLE home_featured_events
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_home_featured_events" ON "home_featured_events";
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
@@ -57,7 +56,6 @@ BEGIN
   END IF;
 END $$;
 
-DROP TRIGGER IF EXISTS set_home_featured_events_updated_at ON home_featured_events;
 CREATE TRIGGER set_home_featured_events_updated_at
   BEFORE UPDATE
   ON home_featured_events
@@ -97,7 +95,6 @@ CREATE INDEX IF NOT EXISTS idx_home_featured_context_expires_at
 ALTER TABLE home_featured_event_context_items
   ENABLE ROW LEVEL SECURITY;
 
-DROP POLICY IF EXISTS "service_role_all_home_featured_event_context_items" ON "home_featured_event_context_items";
 DO $$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role') THEN
@@ -111,7 +108,6 @@ BEGIN
   END IF;
 END $$;
 
-DROP TRIGGER IF EXISTS set_home_featured_event_context_items_updated_at ON home_featured_event_context_items;
 CREATE TRIGGER set_home_featured_event_context_items_updated_at
   BEFORE UPDATE
   ON home_featured_event_context_items

--- a/src/lib/db/migrations/2026_07_13_001_polymarket_mirrors.sql
+++ b/src/lib/db/migrations/2026_07_13_001_polymarket_mirrors.sql
@@ -14,6 +14,19 @@ CREATE TABLE IF NOT EXISTS arbitrage_order_rate_limits (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'arbitrage_order_rate_limits'::regclass
+      AND tgname = 'set_arbitrage_order_rate_limits_updated_at'
+      AND NOT tgisinternal
+  ) THEN
+    DROP TRIGGER set_arbitrage_order_rate_limits_updated_at ON arbitrage_order_rate_limits;
+  END IF;
+END $$;
+
 CREATE TRIGGER set_arbitrage_order_rate_limits_updated_at
   BEFORE UPDATE
   ON arbitrage_order_rate_limits

--- a/src/lib/db/migrations/2026_07_13_001_polymarket_mirrors.sql
+++ b/src/lib/db/migrations/2026_07_13_001_polymarket_mirrors.sql
@@ -14,7 +14,6 @@ CREATE TABLE IF NOT EXISTS arbitrage_order_rate_limits (
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
-DROP TRIGGER IF EXISTS set_arbitrage_order_rate_limits_updated_at ON arbitrage_order_rate_limits;
 CREATE TRIGGER set_arbitrage_order_rate_limits_updated_at
   BEFORE UPDATE
   ON arbitrage_order_rate_limits


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Quiets migration output on fresh databases by removing pre-emptive `DROP` statements and noisy index-creation checks, so first-run migrations no longer print "does not exist" notices.

**Bug Fixes**
- Removes `DROP POLICY` and `DROP TRIGGER` statements for objects that only exist after the migration creates them.
- Rewrites the deposit wallet cutover migration's unique index creation to check `pg_indexes` directly, since `CREATE UNIQUE INDEX IF NOT EXISTS` still emits a notice when the index is missing.
- Moves `POSTGRES_URL` into the required database connection block in `.env.example` and drops redundant SSL comments.

<sup>Written for commit c46db3bddc2eab1f7fe4503a5ce19728bfe56a5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

